### PR TITLE
docs: version typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ On Linux and macOS you can probably download as follows:
 
 ```console
 $ wget https://github.com/instrumenta/conftest/releases/download/v0.4.2/conftest_0.4.2_Linux_x86_64.tar.gz
-$ tar xzf conftest_0.4.0_Linux_x86_64.tar.gz
+$ tar xzf conftest_0.4.2_Linux_x86_64.tar.gz
 $ sudo mv conftest /usr/local/bin
 ```
 


### PR DESCRIPTION
I'd prefer `${_/*\/}` but it's sufficiently indistinguishable from magic...