### PR TITLE
update opa to 0.12.0 for new keywords, fix acceptance for reduced output for trace

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -35,7 +35,7 @@
 @test "Has trace flag" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --trace
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "Enter warn[msg] { data.kubernetes.is_service;" ]]
+  [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
 
 @test "Has help flag" {

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30 // indirect
-	github.com/open-policy-agent/opa v0.10.6
+	github.com/open-policy-agent/opa v0.12.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuB
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/open-policy-agent/opa v0.10.6 h1:oMQEObSE8E3Lck7SSBACvUB/XYtXGUWuz7QbAVnRbpk=
 github.com/open-policy-agent/opa v0.10.6/go.mod h1:rlfeSeHuZmMEpmrcGla42AjkOUjP4rGIpS96H12un3o=
+github.com/open-policy-agent/opa v0.12.0 h1:ocbBbALdMH/JXyC9w8M1P1D82gs57e0xZ4QoRRFREJQ=
+github.com/open-policy-agent/opa v0.12.0/go.mod h1:rlfeSeHuZmMEpmrcGla42AjkOUjP4rGIpS96H12un3o=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=


### PR DESCRIPTION
Hi,

This PR fixes the problem described in #13.
OPA released some new keywords for rego and changed "var" to "some" in v0.12.0.
To use these keywords, we need to upgrade the Opa to the current version.
(https://github.com/open-policy-agent/opa/commit/3263f54a74242f2225d0d7520f401805970c86db)

I tested Conftest with current examples with v0.12.0 
Also, the new version of Opa has reduced output for trace, fixed the acceptance test for trace.
