### PR TITLE
Feature/add rego file support to policy flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s"
 
 
 FROM bats/bats:v1.1.0 as acceptance
-COPY --from=builder /conftest /usr/local/bin
+COPY --from=builder /conftest /
 COPY acceptance.bats /acceptance.bats
 COPY examples /examples
 RUN ./acceptance.bats

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -42,3 +42,9 @@
   run ./conftest --help
   [ "$status" -eq 0 ]
 }
+
+@test "Allow .rego files in the policy flag" {
+  run ./conftest test -p examples/terraform/policy/base.rego examples/terraform/gke-show.json
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Terraform plan will change prohibited resources in the following namespaces: google_iam, google_container" ]]
+}

--- a/conftest.go
+++ b/conftest.go
@@ -224,9 +224,18 @@ func buildRego(trace bool, query string, input interface{}, compiler *ast.Compil
 }
 
 func buildCompiler(path string) (*ast.Compiler, error) {
-	files, err := ioutil.ReadDir(path)
+	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
+	}
+	var files []os.FileInfo
+	var dirPath string
+	if info.IsDir() {
+		files, err = ioutil.ReadDir(path)
+		dirPath = path
+	} else {
+		files = []os.FileInfo{info}
+		dirPath = filepath.Dir(path)
 	}
 
 	modules := map[string]*ast.Module{}
@@ -236,7 +245,7 @@ func buildCompiler(path string) (*ast.Compiler, error) {
 			continue
 		}
 
-		out, err := ioutil.ReadFile(path + "/" + file.Name())
+		out, err := ioutil.ReadFile(dirPath + "/" + file.Name())
 		if err != nil {
 			return nil, err
 		}
@@ -442,7 +451,7 @@ func init() {
 	RootCmd.AddCommand(pushCmd)
 	RootCmd.AddCommand(testCmd)
 
-	RootCmd.PersistentFlags().StringP("policy", "p", "policy", "directory for Rego policy files")
+	RootCmd.PersistentFlags().StringP("policy", "p", "policy", "path to the Rego policy files directory. For the test command, specifying a specific .rego file is allowed.")
 	RootCmd.PersistentFlags().BoolP("debug", "", false, "enable more verbose log output")
 	RootCmd.PersistentFlags().BoolP("trace", "", false, "enable more verbose trace output for rego queries")
 


### PR DESCRIPTION
Fixes #6 

Included support for .rego files on the policy flag. Currently only a single file is allowed. Maybe in the future we can support multiple values.