### PR TITLE
feat: Add Parser interface. Edit processFile method to include use of…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s"
 
 
 FROM bats/bats:v1.1.0 as acceptance
-COPY --from=builder /conftest /usr/local/bin
+COPY --from=builder /conftest /
 COPY acceptance.bats /acceptance.bats
 COPY examples /examples
 RUN ./acceptance.bats

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -42,3 +42,8 @@
   run ./conftest --help
   [ "$status" -eq 0 ]
 }
+
+@test "Can parse toml files" {
+  run ./conftest test -p examples/traefik/policy examples/traefik/traefik.toml
+  [ "$status" -eq 1 ]
+}

--- a/examples/traefik/policy/base.rego
+++ b/examples/traefik/policy/base.rego
@@ -1,0 +1,14 @@
+package main
+
+disallowed_ciphers = [
+    "TLS_RSA_WITH_AES_256_GCM_SHA384"
+]
+
+deny[msg] {
+  check_trusted_ips(input.entryPoints.http.tls.cipherSuites, disallowed_ciphers)
+  msg = sprintf("Following ciphers are not allowed: %v", [disallowed_ciphers])
+}
+
+check_trusted_ips(ciphers, blacklist) {
+  ciphers[_] = blacklist[_]
+}

--- a/examples/traefik/traefik.toml
+++ b/examples/traefik/traefik.toml
@@ -1,0 +1,67 @@
+defaultEntryPoints = ["http", "https"]
+
+[entryPoints]
+  [entryPoints.http]
+    address = ":80"
+    compress = true
+
+    [entryPoints.http.whitelist]
+      sourceRange = ["10.42.0.0/16", "152.89.1.33/32", "afed:be44::/16"]
+      useXForwardedFor = true
+
+    [entryPoints.http.tls]
+      minVersion = "VersionTLS12"
+      cipherSuites = [
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384"
+       ]
+      [[entryPoints.http.tls.certificates]]
+        certFile = "path/to/my.cert"
+        keyFile = "path/to/my.key"
+      [[entryPoints.http.tls.certificates]]
+        certFile = "path/to/other.cert"
+        keyFile = "path/to/other.key"
+      # ...
+      [entryPoints.http.tls.clientCA]
+        files = ["path/to/ca1.crt", "path/to/ca2.crt"]
+        optional = false
+
+    [entryPoints.http.redirect]
+      entryPoint = "https"
+      regex = "^http://localhost/(.*)"
+      replacement = "http://mydomain/$1"
+      permanent = true
+
+    [entryPoints.http.auth]
+      headerField = "X-WebAuth-User"
+      [entryPoints.http.auth.basic]
+        removeHeader = true
+        users = [
+          "test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/",
+          "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0",
+        ]
+        usersFile = "/path/to/.htpasswd"
+      [entryPoints.http.auth.digest]
+        removeHeader = true
+        users = [
+          "test:traefik:a2688e031edb4be6a3797f3882655c05",
+          "test2:traefik:518845800f9e2bfb1f1f740ec24f074e",
+        ]
+        usersFile = "/path/to/.htdigest"
+      [entryPoints.http.auth.forward]
+        address = "https://authserver.com/auth"
+        trustForwardHeader = true
+        authResponseHeaders = ["X-Auth-User"]
+        [entryPoints.http.auth.forward.tls]
+          ca = "path/to/local.crt"
+          caOptional = true
+          cert = "path/to/foo.cert"
+          key = "path/to/foo.key"
+          insecureSkipVerify = true
+
+    [entryPoints.http.proxyProtocol]
+      insecure = true
+      trustedIPs = ["10.10.10.1", "10.10.10.2"]
+
+    [entryPoints.http.forwardedHeaders]
+      trustedIPs = ["10.10.10.1", "10.10.10.2"]

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	cloud.google.com/go v0.39.0 // indirect
+	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
@@ -69,7 +70,7 @@ require (
 	golang.org/x/sys v0.0.0-20190526052359-791d8a0f4d09 // indirect
 	golang.org/x/tools v0.0.0-20190525145741-7be61e1b0e51 // indirect
 	google.golang.org/appengine v1.6.0 // indirect
-	google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69 // indirect
+	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601 // indirect
 	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/cli-runtime v0.0.0-20190515024640-178667528169 // indirect
 	k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a // indirect

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8 h1:x913Lq/RebkvUmR
 google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69 h1:4rNOqY4ULrKzS6twXa619uQgI7h9PaVd4ZhjFQ7C5zs=
 google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
+google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601 h1:9VBRTdmgQxbs6HE0sUnMrSWNePppAJU07NYvX5dIB04=
+google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/util/parser.go
+++ b/util/parser.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/ghodss/yaml"
+)
+
+// Parser is the interface implemented by objects that can unmarshal
+// bytes into a golang interface
+type Parser interface {
+	Unmarshal(p []byte, v interface{}) error
+}
+
+// GetParser returns a Parser for the given file type. If no supported parser is found, it returns an error.
+func GetParser(fileName string) (Parser, error) {
+	suffix := filepath.Ext(fileName)
+	switch suffix {
+	case ".yaml",".yml", ".json":
+		return &yamlParser{
+			fileName: fileName,
+		}, nil
+	case ".toml":
+		return &tomlParser{
+			fileName: fileName,
+		}, nil
+	default:
+		return nil, fmt.Errorf("Unable to find available parser for extension %s", suffix)
+	}
+
+}
+
+type yamlParser struct {
+	fileName string
+}
+
+func (yp *yamlParser) Unmarshal(p []byte, v interface{}) error {
+	err := yaml.Unmarshal(p, v)
+	if err != nil {
+		return fmt.Errorf("Unable to parse YAML from %s: %s", yp.fileName, err)
+	}
+
+	return nil
+}
+
+type tomlParser struct {
+	fileName string
+}
+
+func (tp *tomlParser) Unmarshal(p []byte, v interface{}) error {
+	err := toml.Unmarshal(p, v)
+	if err != nil {
+		return fmt.Errorf("Unable to parse TOML from %s: %s", tp.fileName, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes #1 

Include a generic Parser interface to make it easy to include support for other file formats (e.g. HCL, Dockerfiles, etc.) in the future.