### PR TITLE
Fix decision for repositories including ports

### DIFF
--- a/conftest.go
+++ b/conftest.go
@@ -320,7 +320,7 @@ func downloadPolicy(ctx context.Context, policies []Policy) {
 
 	for _, policy := range policies {
 		var ref string
-		if strings.Contains(policy.Repository, ":") {
+		if util.RepositoryNameContainsTag(policy.Repository) {
 			ref = policy.Repository
 		} else if policy.Tag == "" {
 			ref = policy.Repository + ":latest"

--- a/util/repository.go
+++ b/util/repository.go
@@ -1,0 +1,9 @@
+package util
+
+import "strings"
+
+// RepositoryNameContainsTag checks if the repository name includes a tag
+func RepositoryNameContainsTag(name string) bool {
+	split := strings.Split(name, "/")
+	return strings.Contains(split[len(split)-1], ":")
+}

--- a/util/repository_test.go
+++ b/util/repository_test.go
@@ -1,0 +1,42 @@
+package util
+
+import "testing"
+
+func TestRepositoryNameContainsTag(t *testing.T) {
+	tests := []struct {
+		note           string
+		name           string
+		expectedResult bool
+	}{
+		{
+			note:           "no port, no tag",
+			name:           "instrumenta.azurecr.io/test",
+			expectedResult: false,
+		},
+		{
+			note:           "no port, contains tag",
+			name:           "instrumenta.azurecr.io/test:master",
+			expectedResult: true,
+		},
+		{
+			note:           "contains port, no tag",
+			name:           "localhost:5000/test",
+			expectedResult: false,
+		},
+		{
+			note:           "contains port, contains tag",
+			name:           "localhost:5000/test:master",
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			result := RepositoryNameContainsTag(tc.name)
+			if result != tc.expectedResult {
+				t.Errorf("Expected %v, got %v", tc.expectedResult, result)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Closes #24 

This fixes the issue where `localhost:5000/test` is treated to include a
`tag` because the string includes a `:` in the ports.

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

I've created a different file to test it easier but open to thoughts of how to implement this differently.
Thank you!