### PR TITLE
feat: Add --no-color flag to disable colored output

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -58,3 +58,9 @@
   run ./conftest test -p examples/traefik/policy examples/traefik/traefik.toml
   [ "$status" -eq 1 ]
 }
+
+@test "Can disable color" {
+  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"[33m"* ]]
+}

--- a/conftest.go
+++ b/conftest.go
@@ -109,10 +109,16 @@ var testCmd = &cobra.Command{
 	},
 }
 
+func getAurora() aurora.Aurora {
+	enableColors := viper.GetBool("no-color")
+	return aurora.NewAurora(enableColors)
+}
+
 func printErrors(err error, color aurora.Color) {
+	aur := getAurora()
 	if merr, ok := err.(*multierror.Error); ok {
 		for i := range merr.Errors {
-			fmt.Println("  ", aurora.Colorize(merr.Errors[i], color))
+			fmt.Println("  ", aur.Colorize(merr.Errors[i], color))
 		}
 	} else {
 		fmt.Println(err)
@@ -460,6 +466,7 @@ func init() {
 	testCmd.Flags().BoolP("fail-on-warn", "", false, "return a non-zero exit code if only warnings are found")
 	testCmd.Flags().BoolP("update", "", false, "update any policies before running the tests")
 	RootCmd.PersistentFlags().StringP("namespace", "", "main", "namespace in which to find deny and warn rules")
+	RootCmd.PersistentFlags().BoolP("no-color", "", true, " Disable color when printing;")
 
 	RootCmd.SetVersionTemplate(`{{.Version}}`)
 
@@ -470,6 +477,7 @@ func init() {
 	viper.BindPFlag("fail-on-warn", testCmd.Flags().Lookup("fail-on-warn"))
 	viper.BindPFlag("update", testCmd.Flags().Lookup("update"))
 	viper.BindPFlag("namespace", RootCmd.PersistentFlags().Lookup("namespace"))
+	viper.BindPFlag("color", RootCmd.PersistentFlags().Lookup("color"))
 }
 
 func initConfig() {


### PR DESCRIPTION
Partly Fixes #26 

Added a flag so colorized output could be disabled to make it easier to parse the output in automation