### PR TITLE
creates foundation for configurable output formats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/bugsnag/bugsnag-go v1.5.1 // indirect
 	github.com/containerd/containerd v1.2.6
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect

--- a/pkg/commands/test/output.go
+++ b/pkg/commands/test/output.go
@@ -19,7 +19,8 @@ type stdOutputManager struct {
 	color  aurora.Aurora
 }
 
-// newDefaultStdOutputManager instantiates a new instance of 
+// newDefaultStdOutputManager instantiates a new instance of stdOutputManager
+// using the default logger.
 func newDefaultStdOutputManager(color bool) *stdOutputManager {
 	return newStdOutputManager(log.New(os.Stdout, "", 0), color)
 }

--- a/pkg/commands/test/output.go
+++ b/pkg/commands/test/output.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"github.com/logrusorgru/aurora"
+	"log"
+	"os"
+)
+
+// outputManager controls how results of the `ccheck` evaluation will be recorded
+// and reported to the end user.
+type outputManager interface {
+	put(fileName string, cr checkResult) error
+	flush() error
+}
+
+// stdOutputManager reports `ccheck` results to stdout.
+type stdOutputManager struct {
+	logger *log.Logger
+	color  aurora.Aurora
+}
+
+// newDefaultStdOutputManager instantiates a new instance of 
+func newDefaultStdOutputManager(color bool) *stdOutputManager {
+	return newStdOutputManager(log.New(os.Stdout, "", 0), color)
+}
+
+// newStdOutputManager constructs an instance of stdOutputManager given a
+// logger instance.
+func newStdOutputManager(l *log.Logger, color bool) *stdOutputManager {
+	return &stdOutputManager{
+		logger: l,
+		// control color output within the logger
+		color: aurora.NewAurora(color),
+	}
+}
+
+func (s *stdOutputManager) put(fileName string, cr checkResult) error {
+	if fileName != "-" {
+		s.logger.Println(fileName)
+	}
+
+	// print warnings and then print errors
+	for _, r := range cr.warnings {
+		s.logger.Print("\t", s.color.Colorize(r, aurora.YellowFg))
+	}
+
+	for _, r := range cr.failures {
+		s.logger.Print("\t", s.color.Colorize(r, aurora.RedFg))
+	}
+
+	return nil
+}
+
+func (s *stdOutputManager) flush() error {
+	// no op
+	return nil
+}

--- a/pkg/commands/test/output_test.go
+++ b/pkg/commands/test/output_test.go
@@ -1,0 +1,71 @@
+package test
+
+import (
+	"bytes"
+	"errors"
+	"github.com/bmizerany/assert"
+	"log"
+	"strings"
+	"testing"
+)
+
+func Test_stdOutputManager_put(t *testing.T) {
+	type args struct {
+		fileName string
+		cr       checkResult
+	}
+
+	tests := []struct {
+		msg    string
+		args   args
+		exp    []string
+		expErr error
+	}{
+		{
+			msg: "outputs filenames correctly",
+			args: args{
+				fileName: "foo.yaml",
+				cr: checkResult{
+				},
+			},
+			exp:    []string{"foo.yaml"},
+		},
+		{
+			msg: "records failure and warnings",
+			args: args{
+				fileName: "foo.yaml",
+				cr: checkResult{
+					warnings: []error{errors.New("first warning")},
+					failures: []error{errors.New("first failure")},
+				},
+			},
+			exp:    []string{"foo.yaml", "\tfirst warning", "\tfirst failure"},
+		},
+		{
+			msg: "skips filenames for stdin",
+			args: args{
+				fileName: "-",
+				cr: checkResult{
+					warnings: []error{errors.New("first warning")},
+					failures: []error{errors.New("first failure")},
+				},
+			},
+			exp:    []string{"\tfirst warning", "\tfirst failure"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			s := newStdOutputManager(log.New(buf, "", 0), false)
+
+			err := s.put(tt.args.fileName, tt.args.cr)
+			if err != nil {
+				assert.Equal(t, tt.expErr, err)
+			}
+
+			// split on newlines but remove last one for easier comparisons
+			res := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+			assert.Equal(t, tt.exp, res)
+		})
+	}
+}

--- a/pkg/commands/test/test_test.go
+++ b/pkg/commands/test/test_test.go
@@ -1,10 +1,12 @@
 package test
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestWarnQuerry(t *testing.T) {
 
-	tests := []struct{
+	tests := []struct {
 		in  string
 		exp bool
 	}{
@@ -29,7 +31,7 @@ func TestWarnQuerry(t *testing.T) {
 
 func TestFailQuery(t *testing.T) {
 
-	tests := []struct{
+	tests := []struct {
 		in  string
 		exp bool
 	}{


### PR DESCRIPTION
Creates a new abstraction - `outputManager` which provides a standard interface for recording results from a `conftest` evaluation. For now we simply emulate the standard behavior with a "streaming stdout" sink. This will be expanded upon in later patches to allow multiple types of test output (json, xml etc..).

Related to: https://github.com/instrumenta/conftest/issues/42