### PR TITLE
Improve the default output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,16 @@ Assuming you have a Kubernetes deployment in `deployment.yaml` you can run `conf
 
 ```console
 $ conftest test deployment.yaml
-deployment.yaml
-   Containers must not run as root
-   Deployments are not allowed
+FAIL - deployment.yaml - Containers must not run as root
+FAIL - deployment.yaml - Deployments are not allowed
 ```
 
 `conftest` can also be used with stdin:
 
 ```console
 $ cat deployment.yaml | conftest test -
-deployment.yaml
-   Containers must not run as root
-   Deployments are not allowed
+FAIL - Containers must not run as root
+FAIL - Deployments are not allowed
 ```
 
 Note that `conftest` isn't specific to Kubernetes. It will happily let you write tests for any
@@ -149,7 +147,6 @@ like the following:
 
 ```console
 $ conftest test --trace deployment.yaml
-deployment.yaml
 Enter data.main.deny = _
 | Eval data.main.deny = _
 | Index data.main.deny = _ (matched 2 rules)
@@ -223,8 +220,8 @@ Enter data.main.warn = _
 | Exit data.main.warn = _
 Redo data.main.warn = _
 | Redo data.main.warn = _
-   Containers must not run as root in Deployment hello-kubernetes
-   Deployment hello-kubernetes must provide app/release labels for pod selectors
+FAIL - deployment.yaml - Containers must not run as root in Deployment hello-kubernetes
+FAIL - deployment.yaml - Deployment hello-kubernetes must provide app/release labels for pod selectors
 ```
 
 </details>
@@ -262,13 +259,11 @@ scoop install conftest
 
 ### Docker
 
-Conftest is also able to be used via Docker. Simply mount your configuration and policy at `/project`
-and specify the relevant command like so:
+Conftest is also able to be used via Docker. Simply mount your configuration and policy at `/project` and specify the relevant command like so:
 
 ```console
 $ docker run --rm -v $(pwd):/project instrumenta/conftest test deployment.yaml
-deployment.yaml
-   Containers must not run as root in Deployment hello-kubernetes
+FAIL - deployment.yaml - Containers must not run as root in Deployment hello-kubernetes
 ```
 
 ## Inspiration

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -85,5 +85,5 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 4 ]
+  [ "$count" -eq 3 ]
 }

--- a/pkg/commands/test/output.go
+++ b/pkg/commands/test/output.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"github.com/logrusorgru/aurora"
 	"log"
 	"os"
@@ -36,17 +37,20 @@ func newStdOutputManager(l *log.Logger, color bool) *stdOutputManager {
 }
 
 func (s *stdOutputManager) put(fileName string, cr checkResult) error {
-	if fileName != "-" {
-		s.logger.Println(fileName)
+	var indicator string
+	if fileName == "-" {
+		indicator = " - "
+	} else {
+		indicator = fmt.Sprintf(" - %s - ", fileName)
 	}
 
 	// print warnings and then print errors
 	for _, r := range cr.warnings {
-		s.logger.Print("\t", s.color.Colorize(r, aurora.YellowFg))
+		s.logger.Print(s.color.Colorize("WARN", aurora.YellowFg), indicator, r)
 	}
 
 	for _, r := range cr.failures {
-		s.logger.Print("\t", s.color.Colorize(r, aurora.RedFg))
+		s.logger.Print(s.color.Colorize("FAIL", aurora.RedFg), indicator, r)
 	}
 
 	return nil

--- a/pkg/commands/test/output_test.go
+++ b/pkg/commands/test/output_test.go
@@ -22,15 +22,6 @@ func Test_stdOutputManager_put(t *testing.T) {
 		expErr error
 	}{
 		{
-			msg: "outputs filenames correctly",
-			args: args{
-				fileName: "foo.yaml",
-				cr: checkResult{
-				},
-			},
-			exp:    []string{"foo.yaml"},
-		},
-		{
 			msg: "records failure and warnings",
 			args: args{
 				fileName: "foo.yaml",
@@ -39,7 +30,7 @@ func Test_stdOutputManager_put(t *testing.T) {
 					failures: []error{errors.New("first failure")},
 				},
 			},
-			exp:    []string{"foo.yaml", "\tfirst warning", "\tfirst failure"},
+			exp:    []string{"WARN - foo.yaml - first warning", "FAIL - foo.yaml - first failure"},
 		},
 		{
 			msg: "skips filenames for stdin",
@@ -50,7 +41,7 @@ func Test_stdOutputManager_put(t *testing.T) {
 					failures: []error{errors.New("first failure")},
 				},
 			},
-			exp:    []string{"\tfirst warning", "\tfirst failure"},
+			exp:    []string{"WARN - first warning", "FAIL - first failure"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The previous output suffers from a few issues:

1. You need to read multiple lines to determine the issue and it's
location
2. Without the colors you can't tell errors from warnings
3. It's not easily parsable

This adjusts things according to the discussion in https://github.com/instrumenta/conftest/issues/42