### PR TITLE
adds json output manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/bugsnag/bugsnag-go v1.5.1 // indirect
 	github.com/containerd/containerd v1.2.6
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
@@ -19,8 +18,8 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-ini/ini v1.44.0
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
 	github.com/gorilla/mux v1.7.1 // indirect
-	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/hashicorp/terraform v0.12.3
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
@@ -38,7 +37,7 @@ require (
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.4.0
-	github.com/vchimishuk/chub v0.0.0-20190501162134-36f1f5f7c9ef
+	github.com/stretchr/testify v1.3.0
 	github.com/xenolf/lego v2.5.0+incompatible // indirect
 	github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c h1:7lF+Vz0LqiRidnzC1Oq86fpX1q/iEv2KJdrCtttYjT4=
+github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZsA=
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -292,7 +294,9 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/logrusorgru/aurora v0.0.0-20180419164547-d694e6f975a9/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/logrusorgru/aurora v0.0.0-20190417130405-e50442bb4cb5 h1:1jmSMm6Ob8hsOPlmQuK0NzTzW20mhdSPRuuQWLujSf0=
@@ -485,7 +489,6 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/vchimishuk/chub v0.0.0-20190501162134-36f1f5f7c9ef/go.mod h1:28Qi8YBLQu3Fb3xKnGR9ou2d/PfFz3ptpbZdtsCM++4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=

--- a/pkg/commands/test/output.go
+++ b/pkg/commands/test/output.go
@@ -88,7 +88,9 @@ func newJSONOutputManager(l *log.Logger) *jsonOutputManager {
 }
 
 func errsToStrings(errs []error) []string {
-	var res []string
+	// we explicitly use an empty slice here to ensure that this field will not be
+	// null in json
+	res := []string{}
 	for _, err := range errs {
 		res = append(res, err.Error())
 	}

--- a/pkg/commands/test/output.go
+++ b/pkg/commands/test/output.go
@@ -98,6 +98,10 @@ func errsToStrings(errs []error) []string {
 
 func (j *jsonOutputManager) put(fileName string, cr checkResult) error {
 
+	if fileName == "-" {
+		fileName = ""
+	}
+
 	j.data = append(j.data, jsonCheckResult{
 		Filename: fileName,
 		Warnings: errsToStrings(cr.warnings),

--- a/pkg/commands/test/output_test.go
+++ b/pkg/commands/test/output_test.go
@@ -130,6 +130,25 @@ func Test_jsonOutputManager_put(t *testing.T) {
 ]
 `,
 		},
+		{
+			msg: "handles stdin input",
+			args: args{
+				fileName: "-",
+				cr: checkResult{
+					failures: []error{errors.New("first failure")},
+				},
+			},
+			exp: `[
+	{
+		"filename": "",
+		"warnings": null,
+		"failures": [
+			"first failure"
+		]
+	}
+]
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {

--- a/pkg/commands/test/output_test.go
+++ b/pkg/commands/test/output_test.go
@@ -83,8 +83,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			exp: `[
 	{
 		"filename": "examples/kubernetes/service.yaml",
-		"warnings": null,
-		"failures": null
+		"warnings": [],
+		"failures": []
 	}
 ]
 `,
@@ -122,7 +122,7 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			exp: `[
 	{
 		"filename": "examples/kubernetes/service.yaml",
-		"warnings": null,
+		"warnings": [],
 		"failures": [
 			"first failure"
 		]
@@ -141,7 +141,7 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			exp: `[
 	{
 		"filename": "",
-		"warnings": null,
+		"warnings": [],
 		"failures": [
 			"first failure"
 		]

--- a/pkg/commands/test/output_test.go
+++ b/pkg/commands/test/output_test.go
@@ -3,10 +3,11 @@ package test
 import (
 	"bytes"
 	"errors"
-	"github.com/bmizerany/assert"
 	"log"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_stdOutputManager_put(t *testing.T) {
@@ -30,7 +31,7 @@ func Test_stdOutputManager_put(t *testing.T) {
 					failures: []error{errors.New("first failure")},
 				},
 			},
-			exp:    []string{"WARN - foo.yaml - first warning", "FAIL - foo.yaml - first failure"},
+			exp: []string{"WARN - foo.yaml - first warning", "FAIL - foo.yaml - first failure"},
 		},
 		{
 			msg: "skips filenames for stdin",
@@ -41,7 +42,7 @@ func Test_stdOutputManager_put(t *testing.T) {
 					failures: []error{errors.New("first failure")},
 				},
 			},
-			exp:    []string{"WARN - first warning", "FAIL - first failure"},
+			exp: []string{"WARN - first warning", "FAIL - first failure"},
 		},
 	}
 	for _, tt := range tests {
@@ -57,6 +58,97 @@ func Test_stdOutputManager_put(t *testing.T) {
 			// split on newlines but remove last one for easier comparisons
 			res := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
 			assert.Equal(t, tt.exp, res)
+		})
+	}
+}
+
+func Test_jsonOutputManager_put(t *testing.T) {
+	type args struct {
+		fileName string
+		cr       checkResult
+	}
+
+	tests := []struct {
+		msg    string
+		args   args
+		exp    string
+		expErr error
+	}{
+		{
+			msg: "no warnings or errors",
+			args: args{
+				fileName: "examples/kubernetes/service.yaml",
+				cr:       checkResult{},
+			},
+			exp: `[
+	{
+		"filename": "examples/kubernetes/service.yaml",
+		"warnings": null,
+		"failures": null
+	}
+]
+`,
+		},
+		{
+			msg: "records failure and warnings",
+			args: args{
+				fileName: "examples/kubernetes/service.yaml",
+				cr: checkResult{
+					warnings: []error{errors.New("first warning")},
+					failures: []error{errors.New("first failure")},
+				},
+			},
+			exp: `[
+	{
+		"filename": "examples/kubernetes/service.yaml",
+		"warnings": [
+			"first warning"
+		],
+		"failures": [
+			"first failure"
+		]
+	}
+]
+`,
+		},
+		{
+			msg: "mixed failure and warnings",
+			args: args{
+				fileName: "examples/kubernetes/service.yaml",
+				cr: checkResult{
+					failures: []error{errors.New("first failure")},
+				},
+			},
+			exp: `[
+	{
+		"filename": "examples/kubernetes/service.yaml",
+		"warnings": null,
+		"failures": [
+			"first failure"
+		]
+	}
+]
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			s := newJSONOutputManager(log.New(buf, "", 0))
+
+			// record results
+			err := s.put(tt.args.fileName, tt.args.cr)
+			if err != nil {
+				assert.Equal(t, tt.expErr, err)
+			}
+
+			// flush final buffer
+			err = s.flush()
+			if err != nil {
+				assert.Equal(t, tt.expErr, err)
+			}
+
+			assert.Equal(t, tt.exp, buf.String())
 		})
 	}
 }

--- a/pkg/commands/test/test.go
+++ b/pkg/commands/test/test.go
@@ -83,9 +83,14 @@ func NewTestCommand() *cobra.Command {
 					log.G(ctx).Fatalf("Problem compiling results: %s", err)
 				}
 
-				if len(res.failures) > 0 || (len(res.warnings) > 0 && viper.GetBool("fail-on-warn") ) {
+				if len(res.failures) > 0 || (len(res.warnings) > 0 && viper.GetBool("fail-on-warn")) {
 					foundFailures = true
 				}
+			}
+
+			err = out.flush()
+			if err != nil {
+				log.G(ctx).Fatal(err)
 			}
 
 			if foundFailures {


### PR DESCRIPTION
Adds a new type - `jsonOutputManager` which formats the results of a `ccheck` run as JSON. 

The format of the output is as follows: 

```bash
[
	{
		"filename": "examples/kubernetes/service.yaml",
		"warnings": null,
		"failures": [
			"first failure"
		]
	},
        {
		"filename": "examples/kubernetes/deployment.yaml",
		"warnings": [
			"first warning"
		],
		"failures": [
			"first failure",
			"second failure",
		]
	}
]
```

Example:

```bash
⇒  ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml
[
        {
                "filename": "examples/kubernetes/service.yaml",
                "warnings": [
                        "Found service hello-kubernetes but services are not allowed"
                ],
                "failures": null
        }
]
 
⇒  ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
[
        {
                "filename": "examples/kubernetes/deployment.yaml",
                "warnings": null,
                "failures": [
                        "Containers must not run as root in Deployment hello-kubernetes",
                        "Deployment hello-kubernetes must provide app/release labels for pod selectors",
                        "hello-kubernetes must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels "
                ]
        }
]

```