### PR TITLE
add flag for controlling output format

### DIFF
--- a/pkg/commands/test/output.go
+++ b/pkg/commands/test/output.go
@@ -2,10 +2,31 @@ package test
 
 import (
 	"fmt"
-	"github.com/logrusorgru/aurora"
 	"log"
 	"os"
+
+	"github.com/logrusorgru/aurora"
 )
+
+const (
+	outputSTD = "stdout"
+)
+
+func validOutputs() []string {
+	return []string{
+		outputSTD,
+	}
+}
+
+func getOutputManager(outFmt string, color bool) outputManager {
+	switch outFmt {
+	case outputSTD:
+		return newDefaultStdOutputManager(color)
+		// TOOD (brendanjryan) add more output managers here
+	default:
+		return newDefaultStdOutputManager(color)
+	}
+}
 
 // outputManager controls how results of the `ccheck` evaluation will be recorded
 // and reported to the end user.

--- a/pkg/commands/test/test.go
+++ b/pkg/commands/test/test.go
@@ -63,7 +63,7 @@ func NewTestCommand() *cobra.Command {
 				log.G(ctx).Fatalf("Problem building rego compiler: %s", err)
 			}
 
-			out := newDefaultStdOutputManager(!viper.GetBool("no-color"))
+			out := getOutputManager(viper.GetString("output"), !viper.GetBool("no-color"))
 
 			foundFailures := false
 			for _, fileName := range args {
@@ -83,7 +83,7 @@ func NewTestCommand() *cobra.Command {
 					log.G(ctx).Fatalf("Problem compiling results: %s", err)
 				}
 
-				if len(res.failures) > 0 || (len(res.warnings) > 0 && viper.GetBool("fail-on-warn") ) {
+				if len(res.failures) > 0 || (len(res.warnings) > 0 && viper.GetBool("fail-on-warn")) {
 					foundFailures = true
 				}
 			}
@@ -96,9 +96,11 @@ func NewTestCommand() *cobra.Command {
 
 	cmd.Flags().BoolP("fail-on-warn", "", false, "return a non-zero exit code if only warnings are found")
 	cmd.Flags().BoolP("update", "", false, "update any policies before running the tests")
+	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("output format for conftest results - valid options are: %s", validOutputs()))
 
 	viper.BindPFlag("fail-on-warn", cmd.Flags().Lookup("fail-on-warn"))
 	viper.BindPFlag("update", cmd.Flags().Lookup("update"))
+	viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 
 	return cmd
 }


### PR DESCRIPTION
Adds a command line flag for controlling the output format of the `conftest test` command. For now we only support `stdout` but this will change once we add other output managers (json and xml are slated next!)

Example:
```bash
⇒  ./conftest test --help                           
Test your configuration files using Open Policy Agent

Usage:
  conftest test <file> [file...] [flags]

Flags:
      --fail-on-warn    return a non-zero exit code if only warnings are found
  -h, --help            help for test
  -o, --output string   output format for ccheck results - valid options are: [stdout]
      --update          update any policies before running the tests
      --version         version for test
```