### PR TITLE
fix lint issues reported by golangci-lint

### DIFF
--- a/pkg/commands/test/output.go
+++ b/pkg/commands/test/output.go
@@ -97,10 +97,6 @@ type jsonOutputManager struct {
 	data []jsonCheckResult
 }
 
-func newDefaultJSONOutputManager() *jsonOutputManager {
-	return newJSONOutputManager(log.New(os.Stdout, "", 0))
-}
-
 func newJSONOutputManager(l *log.Logger) *jsonOutputManager {
 	return &jsonOutputManager{
 		logger: l,

--- a/pkg/commands/test/test.go
+++ b/pkg/commands/test/test.go
@@ -286,6 +286,9 @@ func buildCompiler(path string) (*ast.Compiler, error) {
 	var dirPath string
 	if info.IsDir() {
 		files, err = ioutil.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
 		dirPath = path
 	} else {
 		files = []os.FileInfo{info}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -24,7 +24,10 @@ type Policy struct {
 // DownloadPolicy downloads the given policies
 func DownloadPolicy(ctx context.Context, policies []Policy) {
 	policyDir := filepath.Join(".", viper.GetString("policy"))
-	os.MkdirAll(policyDir, os.ModePerm)
+	err := os.MkdirAll(policyDir, os.ModePerm)
+	if err != nil {
+		log.G(ctx).Warnf("Error creating policy directory %q: %v\n", policyDir, err)
+	}
 
 	cli, err := auth.NewClient()
 	if err != nil {


### PR DESCRIPTION
Except for some errcheck findings related to viper that I believe are
commonly ignored:

    $ golangci-lint run ./...
    pkg/commands/commands.go:39:17: Error return value of `viper.BindPFlag` is not checked (errcheck)
            viper.BindPFlag("policy", cmd.PersistentFlags().Lookup("policy"))
                           ^
    pkg/commands/commands.go:40:17: Error return value of `viper.BindPFlag` is not checked (errcheck)
            viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))
                           ^
    pkg/commands/commands.go:41:17: Error return value of `viper.BindPFlag` is not checked (errcheck)
            viper.BindPFlag("trace", cmd.PersistentFlags().Lookup("trace"))
                           ^
    pkg/commands/commands.go:49:20: Error return value of `viper.ReadInConfig` is not checked (errcheck)
            viper.ReadInConfig()
                          ^
ℹ️ Looks like there's a hosted service as well, free for open source projects: https://golangci.com/