### PR TITLE
add input flag for parsing the stdin stream

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -76,6 +76,13 @@
   [[ "$output" =~ "Users should verify their e-mail address" ]]
 }
 
+@test "Can parse stdin with input flag" {
+  run bash -c "cat examples/ini/grafana.ini | ./conftest test -p examples/ini/policy --input ini -"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Users should verify their e-mail address" ]]
+  [[ "$output" != *"Basic auth should be enabled"* ]]
+}
+
 @test "Can disable color" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
   [ "$status" -eq 0 ]

--- a/pkg/parser/input.go
+++ b/pkg/parser/input.go
@@ -1,0 +1,38 @@
+package parser
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// ValidInputs returns string array in order to passing valid input types to viper
+func ValidInputs() []string {
+	return []string{
+		"toml",
+		"tf|hcl",
+		"cue",
+		"ini",
+		"yaml",
+	}
+}
+
+// Input is the struct that used for deciding which type of parser will be applied
+type Input struct {
+	input string
+	fName string
+}
+
+// GetInput returns a valid input object for given fileName and inputType
+func GetInput(fileName string, inputType string) *Input {
+	if inputType != "" {
+		return &Input{
+			input: inputType,
+			fName: fileName,
+		}
+	}
+	suffix := strings.Replace(filepath.Ext(fileName), ".", "", -1)
+	return &Input{
+		input: suffix,
+		fName: fileName,
+	}
+}

--- a/pkg/parser/input_test.go
+++ b/pkg/parser/input_test.go
@@ -1,0 +1,32 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestInputWithinputParam(t *testing.T) {
+	input := &Input{
+		input: "ini",
+		fName: "-",
+	}
+
+	i := GetInput("-", "ini")
+	if i.input != input.input {
+		t.Error("input should be ini with given input param")
+	}
+}
+
+func TestInputWithFileNameParam(t *testing.T) {
+	input := &Input{
+		input: "",
+		fName: "gke.tf",
+	}
+
+	i := GetInput("gke.tf", "")
+	if i.fName != input.fName {
+		t.Error("fileName should passed to object")
+	}
+	if i.input != "tf" {
+		t.Error("input should detected tf with filename suffix")
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"path/filepath"
-
 	"github.com/instrumenta/conftest/pkg/parser/cue"
 	"github.com/instrumenta/conftest/pkg/parser/ini"
 	"github.com/instrumenta/conftest/pkg/parser/terraform"
@@ -16,30 +14,29 @@ type Parser interface {
 	Unmarshal(p []byte, v interface{}) error
 }
 
-// GetParser returns a Parser for the given file type. Defaults to returning the YAML parser.
-func GetParser(fileName string) Parser {
-	suffix := filepath.Ext(fileName)
+// GetParser returns a Parser for the given input type. Defaults to returning the YAML parser.
+func GetParser(i *Input) Parser {
 
-	switch suffix {
-	case ".toml":
+	switch i.input {
+	case "toml":
 		return &toml.Parser{
-			FileName: fileName,
+			FileName: i.fName,
 		}
-	case ".tf":
+	case "tf", "hcl":
 		return &terraform.Parser{
-			FileName: fileName,
+			FileName: i.fName,
 		}
-	case ".cue":
+	case "cue":
 		return &cue.Parser{
-			FileName: fileName,
+			FileName: i.fName,
 		}
-	case ".ini":
+	case "ini":
 		return &ini.Parser{
-			FileName: fileName,
+			FileName: i.fName,
 		}
 	default:
 		return &yaml.Parser{
-			FileName: fileName,
+			FileName: i.fName,
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #69 

This PR adds `--input` flag for using Conftest with stdin or unknown file extensions. 
By default, `--input` flag is the empty string, detection of input type is done with file extensions,
If we pass an input type, it enforces to use with given type.

Example test commands :
```
cat examples/ini/grafana.ini | ./conftest test -p examples/ini/policy/ --input=ini -
cat examples/traefik/traefik.toml | ./conftest test -p examples/traefik/policy/ --input toml -
```
