### PR TITLE
Normalize file path

### DIFF
--- a/pkg/commands/push/push.go
+++ b/pkg/commands/push/push.go
@@ -137,7 +137,10 @@ func buildLayer(ctx context.Context, paths []string, root string, memoryStore *c
 		if err != nil {
 			log.G(ctx).Fatal(err)
 		}
-		layer = memoryStore.Add(relative, constants.OpenPolicyAgentPolicyLayerMediaType, contents)
+
+		path := filepath.ToSlash(relative)
+
+		layer = memoryStore.Add(path, constants.OpenPolicyAgentPolicyLayerMediaType, contents)
 		layers = append(layers, layer)
 	}
 	return layers


### PR DESCRIPTION
Originally found in #71 

Running (on windows)
`conftest push localhost:5000/policies:latest`

Results in
`time="2019-08-10T11:47:27-04:00" level=fatal msg="policy\\base_test.rego: dirty path"`

This error actually originates from oras
https://github.com/deislabs/oras/blob/master/pkg/oras/push_opts.go#L85

