### PR TITLE
added ci examples dir with gitlab ci examples

### DIFF
--- a/examples/ci/gitlab/kubernetes.yaml
+++ b/examples/ci/gitlab/kubernetes.yaml
@@ -1,0 +1,23 @@
+stages:
+  - validate
+  - conformance
+
+validate:
+  stage: validate
+  image:
+    name: garethr/kubeval
+    entrypoint:
+      - ""                          # Override default entrypoint.
+  script:
+    - kubeval --strict deploy/*     # Assume k8s configs are in folder deploy/
+
+conformance:
+  stage: conformance
+  dependancies:
+    - validate
+  image:
+    name: instrumenta/conftest:latest
+    entrypoint:
+      - ""                          # Override default entrypoint. If not included gitlab ci will execute `conftest sh test`
+  script:
+    - conftest test deploy/*        # Assume k8s configs are in folder deploy/

--- a/examples/ci/gitlab/terraform.yaml
+++ b/examples/ci/gitlab/terraform.yaml
@@ -1,0 +1,49 @@
+image:
+  name: hashicorp/terraform:light
+  entrypoint:
+    - '/usr/bin/env'
+    - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+
+stages:
+  - validate
+  - plan
+  - conformance
+  - apply
+
+before_script:
+  - rm -rf .terraform
+  - terraform --version
+  - terraform init
+
+validate:
+  stage: validate
+  script:
+    - terraform validate
+
+plan:
+  stage: plan
+  script:
+    - ls
+    - terraform plan -out "planfile"
+    - terraform show -json "planfile" > "showfile"
+  dependencies:
+    - validate
+  artifacts:
+    untracked: false
+    expire_in: 30 days
+    paths:
+      - planfile
+      - showfile
+
+conftest:
+  stage: conformance
+  image:
+    name: instrumenta/conftest:latest
+    entrypoint:
+      - ""
+  dependencies:
+    - plan
+  before_script:
+    - conftest --version
+  script:
+    - conftest test "$CI_PROJECT_DIR/showfile"


### PR DESCRIPTION
This PR adds a new CI folder to the examples dir and includes 2 examples of using conftest (terraform and k8s) with Gitlab CI. Happy to make any changes if needed.

Thanks for making conftest, it's fantastic :)