### PR TITLE
add hcl2 support

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -81,6 +81,12 @@
   [[ "$output" =~ "Users should verify their e-mail address" ]]
 }
 
+@test "Can parse hcl2 files" {
+  run ./conftest test -p examples/hcl2/policy examples/hcl2/terraform.tf -i hcl2
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Application environment is should be `staging_environment`" ]]
+}
+
 @test "Can parse stdin with input flag" {
   run bash -c "cat examples/ini/grafana.ini | ./conftest test -p examples/ini/policy --input ini -"
   [ "$status" -eq 1 ]

--- a/examples/hcl2/policy/deny.rego
+++ b/examples/hcl2/policy/deny.rego
@@ -1,0 +1,26 @@
+package main
+
+
+deny[msg] {
+  not input["resource.aws_elastic_beanstalk_environment.example"].application = "testing"
+  msg = "Application is should be `testing`"
+}
+
+deny[msg] {
+  not input["resource.aws_elastic_beanstalk_environment.example"].application = "staging_environment"
+  msg = "Application environment is should be `staging_environment`"
+}
+
+deny[msg] {
+  output := sprintf("%s", [input["resource.aws_elastic_beanstalk_environment.example"].setting])
+  status = contains(output, "\"namespace\": \"aws:autoscaling:asg\"")
+  not status
+  msg = "The namespace should defined as `aws:autoscaling:asg`"
+}
+
+deny[msg] {
+  output := input["resource.aws_elastic_beanstalk_environment.example"]["dynamic.setting"].for_each
+  status = contains(output, "${data.consul_key_prefix.environment.var}")
+  not status
+  msg = "aws_elastic_beanstalk_environment dynamic.setting should contains a valid `for_each` `equals to data.consul_key_prefix.environment.var`"
+}

--- a/examples/hcl2/terraform.tf
+++ b/examples/hcl2/terraform.tf
@@ -1,0 +1,34 @@
+data "consul_key_prefix" "environment" {
+  path = "apps/example/env"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name        = "test_environment"
+  application = "testing"
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = "1"
+  }
+
+  dynamic "setting" {
+    for_each = data.consul_key_prefix.environment.var
+    content {
+      namespace = "aws:elasticbeanstalk:application:environment"
+      name      = setting.key
+      value     = setting.value
+    }
+  }
+}
+
+output "environment" {
+  value = {
+    id           = aws_elastic_beanstalk_environment.example.id
+    vpc_settings = {
+      for s in aws_elastic_beanstalk_environment.example.all_settings :
+      s.name => s.value
+      if s.namespace == "aws:ec2:vpc"
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gorilla/mux v1.7.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/hashicorp/hcl v1.0.0
+	github.com/hashicorp/hcl2 v0.0.0-20190618163856-0b64543c968c
 	github.com/hashicorp/terraform v0.12.3
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20190417130405-e50442bb4cb5
@@ -42,6 +43,7 @@ require (
 	github.com/xenolf/lego v2.5.0+incompatible // indirect
 	github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
+	github.com/zclconf/go-cty v1.0.0
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f // indirect
 	golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0 // indirect
 	google.golang.org/appengine v1.6.0 // indirect

--- a/pkg/parser/hcl2/convert.go
+++ b/pkg/parser/hcl2/convert.go
@@ -1,0 +1,169 @@
+package hcl2
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	ctyconvert "github.com/zclconf/go-cty/cty/convert"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// This file is attributed to https://github.com/tmccombs/hcl2json.
+// convertBlock() is manipulated for combining the both blocks and labels for one given resource.
+
+type jsonObj map[string]interface{}
+
+// Convert an hcl File to a json serializable object
+// This assumes that the body is a hclsyntax.Body
+func convertFile(file *hcl.File) (jsonObj, error) {
+	c := converter{bytes: file.Bytes}
+	body := file.Body.(*hclsyntax.Body)
+	return c.convertBody(body)
+}
+
+type converter struct {
+	bytes []byte
+}
+
+func (c *converter) rangeSource(r hcl.Range) string {
+	return string(c.bytes[r.Start.Byte:r.End.Byte])
+}
+
+func (c *converter) convertBody(body *hclsyntax.Body) (jsonObj, error) {
+	var err error
+	out := make(jsonObj)
+	for key, value := range body.Attributes {
+		out[key], err = c.convertExpression(value.Expr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, block := range body.Blocks {
+		err = c.convertBlock(block, out)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+func (c *converter) convertBlock(block *hclsyntax.Block, out jsonObj) error {
+	var key string = block.Type
+
+	for _, label := range block.Labels {
+		key = fmt.Sprintf("%s.%s", key, label)
+	}
+
+	value, err := c.convertBody(block.Body)
+	if err != nil {
+		return err
+	}
+	out[key] = value
+	return nil
+}
+
+func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, error) {
+	// assume it is hcl syntax (because, um, it is)
+	switch value := expr.(type) {
+	case *hclsyntax.LiteralValueExpr:
+		return ctyjson.SimpleJSONValue{Value: value.Val}, nil
+	case *hclsyntax.TemplateExpr:
+		return c.convertTemplate(value)
+	case *hclsyntax.TemplateWrapExpr:
+		return c.convertExpression(value.Wrapped)
+	default:
+		return c.wrapExpr(expr), nil
+	}
+}
+
+func (c *converter) convertTemplate(t *hclsyntax.TemplateExpr) (string, error) {
+	if t.IsStringLiteral() {
+		// safe because the value is just the string
+		v, err := t.Value(nil)
+		if err != nil {
+			return "", err
+		}
+		return v.AsString(), nil
+	}
+	var builder strings.Builder
+	for _, part := range t.Parts {
+		s, err := c.convertStringPart(part)
+		if err != nil {
+			return "", err
+		}
+		builder.WriteString(s)
+	}
+	return builder.String(), nil
+}
+
+func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error) {
+	switch v := expr.(type) {
+	case *hclsyntax.LiteralValueExpr:
+		s, err := ctyconvert.Convert(v.Val, cty.String)
+		if err != nil {
+			return "", err
+		}
+		return s.AsString(), nil
+	case *hclsyntax.TemplateExpr:
+		return c.convertTemplate(v)
+	case *hclsyntax.TemplateWrapExpr:
+		return c.convertStringPart(v.Wrapped)
+	case *hclsyntax.ConditionalExpr:
+		return c.convertTemplateConditional(v)
+	case *hclsyntax.TemplateJoinExpr:
+		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
+	default:
+		// treating as an embedded expression
+		return c.wrapExpr(expr), nil
+	}
+}
+
+func (c *converter) convertTemplateConditional(expr *hclsyntax.ConditionalExpr) (string, error) {
+	var builder strings.Builder
+	builder.WriteString("%{if ")
+	builder.WriteString(c.rangeSource(expr.Condition.Range()))
+	builder.WriteString("}")
+	trueResult, err := c.convertStringPart(expr.TrueResult)
+	if err != nil {
+		return "", nil
+	}
+	builder.WriteString(trueResult)
+	falseResult, err := c.convertStringPart(expr.FalseResult)
+	if len(falseResult) > 0 {
+		builder.WriteString("%{else}")
+		builder.WriteString(falseResult)
+	}
+	builder.WriteString("%{endif}")
+
+	return builder.String(), nil
+}
+
+func (c *converter) convertTemplateFor(expr *hclsyntax.ForExpr) (string, error) {
+	var builder strings.Builder
+	builder.WriteString("%{for ")
+	if len(expr.KeyVar) > 0 {
+		builder.WriteString(expr.KeyVar)
+		builder.WriteString(", ")
+	}
+	builder.WriteString(expr.ValVar)
+	builder.WriteString(" in ")
+	builder.WriteString(c.rangeSource(expr.CollExpr.Range()))
+	builder.WriteString("}")
+	templ, err := c.convertStringPart(expr.ValExpr)
+	if err != nil {
+		return "", err
+	}
+	builder.WriteString(templ)
+	builder.WriteString("%{endfor}")
+
+	return builder.String(), nil
+}
+
+func (c *converter) wrapExpr(expr hclsyntax.Expression) string {
+	return "${" + c.rangeSource(expr.Range()) + "}"
+}

--- a/pkg/parser/hcl2/convert.go
+++ b/pkg/parser/hcl2/convert.go
@@ -134,6 +134,9 @@ func (c *converter) convertTemplateConditional(expr *hclsyntax.ConditionalExpr) 
 	}
 	builder.WriteString(trueResult)
 	falseResult, err := c.convertStringPart(expr.FalseResult)
+	if err != nil {
+		return "", nil
+	}
 	if len(falseResult) > 0 {
 		builder.WriteString("%{else}")
 		builder.WriteString(falseResult)

--- a/pkg/parser/hcl2/convert_test.go
+++ b/pkg/parser/hcl2/convert_test.go
@@ -1,0 +1,94 @@
+package hcl2
+
+import (
+	"encoding/json"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+	"testing"
+)
+
+// This file is mostly attributed to https://github.com/tmccombs/hcl2json
+// It tests for merging block and labels for the given resource.
+
+const input = `
+resource "aws_elastic_beanstalk_environment" "example" {
+	name        = "test_environment"
+	application = "testing"
+  
+	setting {
+	  namespace = "aws:autoscaling:asg"
+	  name      = "MinSize"
+	  value     = "1"
+	}
+  
+	dynamic "setting" {
+	  for_each = data.consul_key_prefix.environment.var
+	  content {
+		heredoc = <<-EOF
+		This is a heredoc template.
+		It references ${local.other.3}
+		EOF
+		simple = "${4 - 2}"
+		cond = test3 > 2 ? 1: 0
+		heredoc2 = <<EOF
+			Another heredoc, that
+			doesn't remove indentation
+			${local.other.3}
+			%{if true ? false : true}"gotcha"\n%{else}4%{endif}
+		EOF
+		loop = "This has a for loop: %{for x in local.arr}x,%{endfor}"
+		namespace = "aws:elasticbeanstalk:application:environment"
+		name      = setting.key
+		value     = setting.value
+	  }
+	}
+  }`
+
+const expectedJSON = `{
+	"resource.aws_elastic_beanstalk_environment.example": {
+		"application": "testing",
+		"dynamic.setting": {
+			"content": {
+				"cond": "${test3 \u003e 2 ? 1: 0}",
+				"heredoc": "This is a heredoc template.\nIt references ${local.other.3}\n",
+				"heredoc2": "\t\t\tAnother heredoc, that\n\t\t\tdoesn't remove indentation\n\t\t\t${local.other.3}\n\t\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",
+				"loop": "This has a for loop: %{for x in local.arr}x,%{endfor}",
+				"name": "${setting.key}",
+				"namespace": "aws:elasticbeanstalk:application:environment",
+				"simple": "${4 - 2}",
+				"value": "${setting.value}"
+			},
+			"for_each": "${data.consul_key_prefix.environment.var}"
+		},
+		"name": "test_environment",
+		"setting": {
+			"name": "MinSize",
+			"namespace": "aws:autoscaling:asg",
+			"value": "1"
+		}
+	}
+}`
+
+// Test that conversion works as expected
+func TestConversion(t *testing.T) {
+	bytes := []byte(input)
+	conf, diags := hclsyntax.ParseConfig(bytes, "test", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Errorf("Failed to parse config: %v", diags)
+	}
+	converted, err := convertFile(conf)
+
+	if err != nil {
+		t.Errorf("Unable to convert from hcl: %v", err)
+	}
+
+	jb, err := json.MarshalIndent(converted, "", "\t")
+	if err != nil {
+		t.Errorf("Failed to serialize to json: %v", err)
+	}
+	computedJSON := string(jb)
+
+	if computedJSON != expectedJSON {
+		t.Errorf("Expected:\n%s\n\nGot:\n%s", expectedJSON, computedJSON)
+	}
+}

--- a/pkg/parser/hcl2/hcl2.go
+++ b/pkg/parser/hcl2/hcl2.go
@@ -1,0 +1,43 @@
+package hcl2
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
+)
+
+type Parser struct {
+	FileName string
+}
+
+func (h *Parser) Unmarshal(p []byte, v interface{}) error {
+	file, diags := hclsyntax.ParseConfig(p, "", hcl.Pos{Line: 1, Column: 1})
+
+	if diags.HasErrors() {
+		for _, diag := range diags {
+			fmt.Println(diag.Error())
+		}
+		return fmt.Errorf("Error occured while parsing HCL2 config")
+	}
+
+	content, err := convertFile(file)
+
+	if err != nil {
+		return fmt.Errorf("Unable to convert config %s", err)
+	}
+
+	j, err := json.Marshal(content)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal config: %s", err)
+	}
+
+	err = yaml.Unmarshal(j, v)
+	if err != nil {
+		return fmt.Errorf("Unable to parse YAML from HCL-json: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/instrumenta/conftest/pkg/parser/terraform"
 	"github.com/instrumenta/conftest/pkg/parser/toml"
 	"github.com/instrumenta/conftest/pkg/parser/yaml"
+	"github.com/instrumenta/conftest/pkg/parser/hcl2"
 )
 
 // ValidInputs returns string array in order to passing valid input types to viper
@@ -109,6 +110,8 @@ func GetParser(fileType string) (Parser, error) {
 		return &cue.Parser{}, nil
 	case "ini":
 		return &ini.Parser{}, nil
+	case "hcl2":
+		return &hcl2.Parser{}, nil
 	case "Dockerfile":
 		return &docker.Parser{}, nil
 	case "yml", "yaml", "json":


### PR DESCRIPTION
Fixes #78.

The hcl2 input can be used with `-i hcl2` flag. 
The issues with hcl2 to JSON is still discussed in https://github.com/hashicorp/hcl2/issues/44 so there is no exact way to transform it into structured data for now.
That's why the original `.tf` the extension should use with classic `hcl` parser.
https://github.com/tmccombs/hcl2json 's files are used, simplified and referenced to the original repo. 
The translation can be refactored in the future, however, for now, it's enough for writing tests against `hcl2`.

The example of Terraform 0.12 input copied from https://www.hashicorp.com/blog/announcing-terraform-0-12