### PR TITLE
bugfix : default stdin behavior is fixed to yaml, change log prints to errorf

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -20,9 +20,9 @@
   [ "$status" -eq 0 ]
 }
 
-@test "Pass when testing a YAML document via stdin filetype is required" {
+@test "when testing a YAML document via stdin, default parser should be yaml if no input flag is passed" {
   run ./conftest test -p examples/kubernetes/policy - < examples/kubernetes/service.yaml
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
 }
 
 @test "Pass when testing a YAML document via stdin" {

--- a/pkg/commands/test/test.go
+++ b/pkg/commands/test/test.go
@@ -70,12 +70,12 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 				var config io.ReadCloser
 				fileType, err = getFileType(viper.GetString("input"), fileName)
 				if err != nil {
-					log.G(ctx).Printf("Unable to get file type: %v", err)
+					log.G(ctx).Errorf("Unable to get file type: %v", err)
 					osExit(1)
 				}
 				config, err = getConfig(fileName)
 				if err != nil {
-					log.G(ctx).Printf("Unable to open file or read from stdin %s", err)
+					log.G(ctx).Errorf("Unable to open file or read from stdin %s", err)
 					osExit(1)
 				}
 				configFiles = append(configFiles, parser.ConfigDoc{
@@ -86,7 +86,7 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 			configManager := parser.NewConfigManager(fileType)
 			configurations, err := configManager.BulkUnmarshal(configFiles)
 			if err != nil {
-				log.G(ctx).Printf("Unable to BulkUnmarshal your config files: %v", err)
+				log.G(ctx).Errorf("Unable to BulkUnmarshal your config files: %v", err)
 				osExit(1)
 			}
 
@@ -178,6 +178,9 @@ func getFileType(inputFileType, fileName string) (string, error) {
 	if inputFileType != "" {
 		return inputFileType, nil
 	}
+	if fileName == "-" && inputFileType == "" {
+		return "yaml", nil
+	}
 	if fileName != "-" {
 		fileType := ""
 		if strings.Contains(fileName, ".") {
@@ -188,9 +191,6 @@ func getFileType(inputFileType, fileName string) (string, error) {
 		}
 
 		return fileType, nil
-	}
-	if fileName == "-" && inputFileType == "" {
-		return "", fmt.Errorf("You must define an input type to read from stdin")
 	}
 	return "", fmt.Errorf("not supported filetype")
 }


### PR DESCRIPTION
According to the docs,

expected:
```console
$ cat deployment.yaml | conftest test -
FAIL - Containers must not run as root
FAIL - Deployments are not allowed
```

got:
```console
$ cat deployment.yaml | conftest test -  # or cat examples/kubernetes/deployment.yaml  | ./conftest test -p examples/kubernetes/policy/ -
(nothing, also the err msg: "You must define an input type to read from stdin" is not printed )
```

Fixed the default stdin behavior to `yaml` as documented.
Fixed the `err` printing problem.