### PR TITLE
Structured errors

### DIFF
--- a/examples/traefik/policy/base.rego
+++ b/examples/traefik/policy/base.rego
@@ -4,7 +4,7 @@ disallowed_ciphers = [
     "TLS_RSA_WITH_AES_256_GCM_SHA384"
 ]
 
-deny[msg] {
+deny[{"msg": msg, "not_allowed": disallowed_ciphers, "used": input.entryPoints.http.tls.cipherSuites}] {
   check_trusted_ips(input.entryPoints.http.tls.cipherSuites, disallowed_ciphers)
   msg = sprintf("Following ciphers are not allowed: %v", [disallowed_ciphers])
 }

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -130,7 +130,7 @@ func NewJSONOutputManager(l *log.Logger, details bool) *jsonOutputManager {
 	}
 }
 
-func errsToOutput(errs []error, details bool) []interface{} {
+func violationsToOutput(errs []Violation, details bool) []interface{} {
 	// we explicitly use an empty slice here to ensure that this field will not be
 	// null in json
 	res := make([]interface{}, 0, len(errs))
@@ -141,14 +141,7 @@ func errsToOutput(errs []error, details bool) []interface{} {
 			continue
 		}
 
-		if s, ok := err.(StructuredError); ok {
-			res = append(res, s)
-			continue
-		}
-
-		res = append(res, map[string]interface{}{
-			"msg": err.Error(),
-		})
+		res = append(res, err)
 	}
 
 	return res
@@ -162,9 +155,9 @@ func (j *jsonOutputManager) Put(fileName string, cr CheckResult) error {
 
 	j.data = append(j.data, jsonCheckResult{
 		Filename:  fileName,
-		Warnings:  errsToOutput(cr.Warnings, j.details),
-		Failures:  errsToOutput(cr.Failures, j.details),
-		Successes: errsToOutput(cr.Successes, j.details),
+		Warnings:  violationsToOutput(cr.Warnings, j.details),
+		Failures:  violationsToOutput(cr.Failures, j.details),
+		Successes: violationsToOutput(cr.Successes, j.details),
 	})
 
 	return nil

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"errors"
 	"log"
 	"reflect"
 	"strings"
@@ -28,8 +27,8 @@ func Test_stdOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "foo.yaml",
 				cr: CheckResult{
-					Warnings: []error{errors.New("first warning")},
-					Failures: []error{errors.New("first failure")},
+					Warnings: []Violation{NewViolation("first warning")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: []string{"WARN - foo.yaml - first warning", "FAIL - foo.yaml - first failure"},
@@ -39,8 +38,8 @@ func Test_stdOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "-",
 				cr: CheckResult{
-					Warnings: []error{errors.New("first warning")},
-					Failures: []error{errors.New("first failure")},
+					Warnings: []Violation{NewViolation("first warning")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: []string{"WARN - first warning", "FAIL - first failure"},
@@ -97,8 +96,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "examples/kubernetes/service.yaml",
 				cr: CheckResult{
-					Warnings: []error{errors.New("first warning")},
-					Failures: []error{errors.New("first failure")},
+					Warnings: []Violation{NewViolation("first warning")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: `[
@@ -120,7 +119,7 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "examples/kubernetes/service.yaml",
 				cr: CheckResult{
-					Failures: []error{errors.New("first failure")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: `[
@@ -140,7 +139,7 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "-",
 				cr: CheckResult{
-					Failures: []error{errors.New("first failure")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: `[
@@ -160,17 +159,17 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "-",
 				cr: CheckResult{
-					Failures: []error{StructuredError{"msg": "structured failure", "code": "ERR0001"}},
+					Failures: []Violation{{"msg": "structured failure", "code": "ERR0001"}},
 				},
 			},
 			exp: `[
 	{
 		"filename": "",
-		"Warnings": [],
-		"Failures": [
+		"warnings": [],
+		"failures": [
 			"structured failure"
 		],
-		"Successes": []
+		"successes": []
 	}
 ]
 `,
@@ -181,20 +180,20 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "-",
 				cr: CheckResult{
-					Failures: []error{StructuredError{"msg": "structured failure", "code": "ERR0001"}},
+					Failures: []Violation{{"msg": "structured failure", "code": "ERR0001"}},
 				},
 			},
 			exp: `[
 	{
 		"filename": "",
-		"Warnings": [],
-		"Failures": [
+		"warnings": [],
+		"failures": [
 			{
 				"code": "ERR0001",
 				"msg": "structured failure"
 			}
 		],
-		"Successes": []
+		"successes": []
 	}
 ]
 `,
@@ -287,8 +286,8 @@ func Test_tapOutputManager_put(t *testing.T) {
 			args: args{
 				fileName: "examples/kubernetes/service.yaml",
 				cr: CheckResult{
-					Warnings: []error{errors.New("first warning")},
-					Failures: []error{errors.New("first failure")},
+					Warnings: []Violation{NewViolation("first warning")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: `1..2
@@ -302,7 +301,7 @@ not ok 2 - examples/kubernetes/service.yaml - first warning
 			args: args{
 				fileName: "examples/kubernetes/service.yaml",
 				cr: CheckResult{
-					Failures: []error{errors.New("first failure")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: `1..1
@@ -314,7 +313,7 @@ not ok 1 - examples/kubernetes/service.yaml - first failure
 			args: args{
 				fileName: "-",
 				cr: CheckResult{
-					Failures: []error{errors.New("first failure")},
+					Failures: []Violation{NewViolation("first failure")},
 				},
 			},
 			exp: `1..1

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -89,13 +89,13 @@ func runVerification(ctx context.Context, path string, trace bool) ([]CheckResul
 		msg := fmt.Errorf("%s", result.Package+"."+result.Name)
 		fileName := filepath.Join(path, result.Location.File)
 
-		var failure []error
-		var success []error
+		var failure []Violation
+		var success []Violation
 
 		if result.Fail {
-			failure = []error{msg}
+			failure = []Violation{NewViolation(msg.Error())}
 		} else {
-			success = []error{msg}
+			success = []Violation{NewViolation(msg.Error())}
 		}
 
 		result := CheckResult{


### PR DESCRIPTION
Initial work on structured errors (#96).

This is just to see if I could get it working, it adds the possibility of structured errors by defining rules as follows:
```
deny[{"msg": msg, "foo": bar}] {
  bar = input.bar
  msg = "Something happened"
}
```

By default, if the deny/warn is an object the `msg` property will render as the error. The only way to get other data out is through the `json` output with the `--details` command line option.