### PR TITLE
fix: Output flag viper binding is overwritten if used by two commands…

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -127,3 +127,13 @@
   [ "$status" -eq 0 ]
   [[ "$output" =~ "test_services_not_denied" ]]
 }
+
+@test "Can change output format in test command" {
+  run ./conftest test -p examples/kubernetes/policy/ -o tap examples/kubernetes/deployment.yaml
+  [[ "$output" =~ "not ok" ]]
+}
+
+@test "Can change output format in verify command" {
+  run ./conftest verify -p examples/kubernetes/policy/ -o tap
+  [[ "$output" =~ "ok" ]]
+}

--- a/pkg/commands/test/test.go
+++ b/pkg/commands/test/test.go
@@ -48,6 +48,16 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 		Use:   "test <file> [file...]",
 		Short: "Test your configuration files using Open Policy Agent",
 		Version: fmt.Sprintf("Version: %s\nCommit: %s\nDate: %s\n", constants.Version, constants.Commit, constants.Date),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			var err error
+			flagNames := []string{"fail-on-warn", "update", CombineConfigFlagName, "output", "input"}
+			for _, name := range flagNames {
+				err = viper.BindPFlag(name, cmd.Flags().Lookup(name))
+				if err != nil {
+					log.G(ctx).Fatal("Failed to bind argument:", err)
+				}
+			}
+		},
 		Run: func(cmd *cobra.Command, fileList []string) {
 			out := getOutputManager()
 			if len(fileList) < 1 {
@@ -114,15 +124,6 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 
 	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("output format for conftest results - valid options are: %s", ValidOutputs()))
 	cmd.Flags().StringP("input", "i", "", fmt.Sprintf("input type for given source, especially useful when using conftest with stdin, valid options are: %s", parser.ValidInputs()))
-
-	var err error
-	flagNames := []string{"fail-on-warn", "update", CombineConfigFlagName, "output", "input"}
-	for _, name := range flagNames {
-		err = viper.BindPFlag(name, cmd.Flags().Lookup(name))
-		if err != nil {
-			log.G(ctx).Fatal("Failed to bind argument:", err)
-		}
-	}
 
 	return cmd
 }

--- a/pkg/commands/verify/verify.go
+++ b/pkg/commands/verify/verify.go
@@ -22,7 +22,12 @@ func NewVerifyCommand(getOutputManager func() test.OutputManager) *cobra.Command
 		Use:   "verify",
 		Short: "Verify Rego unit tests",
 		Version: fmt.Sprintf("Version: %s\nCommit: %s\nDate: %s\n", constants.Version, constants.Commit, constants.Date),
-
+		PreRun: func(cmd *cobra.Command, args []string) {
+			err := viper.BindPFlag("output", cmd.Flags().Lookup("output"))
+			if err != nil {
+				log.G(ctx).Fatal("Failed to bind argument:", err)
+			}		
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			out := getOutputManager()
 
@@ -66,10 +71,6 @@ func NewVerifyCommand(getOutputManager func() test.OutputManager) *cobra.Command
 	}
 
 	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("output format for conftest results - valid options are: %s", test.ValidOutputs()))
-	err := viper.BindPFlag("output", cmd.Flags().Lookup("output"))
-	if err != nil {
-		log.G(ctx).Fatal("Failed to bind argument:", err)
-	}
 
 	return cmd
 }


### PR DESCRIPTION
Fixes #104 

Viper silently overwrites the binding of a flag if it is already bound by another command. This broke the output flag for the test command due to that flag being overwritten by the verify command. I included some simple acceptance tests as they where missing.