### PR TITLE
Shorten combine-config flag to combine

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ $ conftest test -p examples/hcl2/policy examples/hcl2/terraform.tf -i hcl2
 FAIL - examples/hcl2/terraform.tf - Application environment is should be `staging_environment`
 ```
 
-#### --combine-config flag
-Of note is the `--combine-config` flag that is sub flag for `conftest test`, ala `conftest test --combine-config`. This flag introduces *BREAKING CHANGES* in how `conftest` provides input to rego policies. However, you may find it useful to as you can now compare multiple values from different configurations simultaneously.
+#### --combine flag
+Of note is the `--combine` flag that is sub flag for `conftest test`, ala `conftest test --combine`. This flag introduces *BREAKING CHANGES* in how `conftest` provides input to rego policies. However, you may find it useful to as you can now compare multiple values from different configurations simultaneously.
 
 Let's try it
 
@@ -124,12 +124,12 @@ spec:
 ```
 
 
-The `--combine-config` flag combines files into one `input` data structure. The structure is a `map` where each indice is the file path of the file being evaluated. 
+The `--combine` flag combines files into one `input` data structure. The structure is a `map` where each indice is the file path of the file being evaluated. 
 
 Assuming you have a Kubernetes deployment in `deployment.yaml` and a kubernetes service definition in `service.yaml` you can run `conftest` like so:
 
 ```console
-$ conftest test --combine-config deployment.yaml service.yaml
+$ conftest test --combine deployment.yaml service.yaml
 
 FAIL - Combined-configs (multi-file) - Expected these values to be the same but received hello-kubernetes for deployment and goodbye-kubernetes for service
 ```

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -100,7 +100,7 @@
 }
   
 @test "Can combine configs and reference by file" {
-  run ./conftest test -p examples/terraform/policy/gke_combine.rego examples/terraform/gke.tf --combine-config
+  run ./conftest test -p examples/terraform/policy/gke_combine.rego examples/terraform/gke.tf --combine
   [ "$status" -eq 0 ]
 }
 

--- a/pkg/commands/test/test.go
+++ b/pkg/commands/test/test.go
@@ -28,7 +28,7 @@ import (
 var (
 	DenyQ                 = regexp.MustCompile("^(deny|violation)(_[a-zA-Z]+)*$")
 	WarnQ                 = regexp.MustCompile("^warn(_[a-zA-Z]+)*$")
-	CombineConfigFlagName = "combine-config"
+	CombineConfigFlagName = "combine"
 )
 
 // CheckResult describes the result of a conftest evaluation.

--- a/pkg/commands/test/test_test.go
+++ b/pkg/commands/test/test_test.go
@@ -45,25 +45,25 @@ func TestCombineConfig(t *testing.T) {
 		fileList          []string
 	}{
 		{
-			name:              "valid policy with combine-config=true should namespace the configs into a map (single file)",
+			name:              "valid policy with combine=true should namespace the configs into a map (single file)",
 			combineConfigFlag: true,
 			policyPath:        "testdata/policy/test_policy_multifile.rego",
 			fileList:          []string{"testdata/deployment.yaml"},
 		},
 		{
-			name:              "config combine-config=false no namespacing, individual evaluation (single file)",
+			name:              "config combine=false no namespacing, individual evaluation (single file)",
 			combineConfigFlag: false,
 			policyPath:        "testdata/policy/test_policy.rego",
 			fileList:          []string{"testdata/deployment.yaml"},
 		},
 		{
-			name:              "config combine-config=false no namespacing, individual evaluation (multi-file)",
+			name:              "config combine=false no namespacing, individual evaluation (multi-file)",
 			combineConfigFlag: false,
 			policyPath:        "testdata/policy/test_policy.rego",
 			fileList:          []string{"testdata/deployment+service.yaml", "testdata/deployment.yaml"},
 		},
 		{
-			name:              "valid policy with combine-config=true should namespace the configs into a map (multi-file)",
+			name:              "valid policy with combine=true should namespace the configs into a map (multi-file)",
 			combineConfigFlag: true,
 			policyPath:        "testdata/policy/test_policy_multifile.rego",
 			fileList:          []string{"testdata/deployment+service.yaml", "testdata/deployment.yaml"},
@@ -85,29 +85,29 @@ func TestCombineConfig(t *testing.T) {
 			cmd.Run(cmd, testunit.fileList)
 			if outputPrinter.PutCallCount() != len(testunit.fileList) && !testunit.combineConfigFlag {
 				t.Errorf(
-					"Output manager when combine-config is false should print output for each file: expected %v calls but got %v",
+					"Output manager when combine is false should print output for each file: expected %v calls but got %v",
 					len(testunit.fileList),
 					outputPrinter.PutCallCount(),
 				)
 			}
 			if errorExitCodeFromCall == 0 && testunit.combineConfigFlag {
 				t.Errorf(
-					"Output manager when combine-config is true should have failed but it exited with a zero code: %v",
+					"Output manager when combine is true should have failed but it exited with a zero code: %v",
 					errorExitCodeFromCall,
 				)
 			}
 		})
 	}
 
-	t.Run("combine-config flag exists", func(t *testing.T) {
+	t.Run("combine flag exists", func(t *testing.T) {
 		callCount := 0
 		cmd := NewTestCommand(func(int) {
 			callCount += 1
 		}, func() OutputManager {
 			return new(FakeOutputManager)
 		})
-		if cmd.Flag("combine-config") == nil {
-			t.Errorf("combine-config flag should exist")
+		if cmd.Flag("combine") == nil {
+			t.Errorf("combine flag should exist")
 		}
 	})
 }


### PR DESCRIPTION
I think in hindsight the combine flag can be shorter. The extra hyphen
and config part are lots to type for limited extra value. The test
command isn't test-config for example

What do folks think?

cc. @Salamandastron1 