### PR TITLE
Don't always load _test.rego files in recursivelySearchDirForRegoFiles

### DIFF
--- a/pkg/commands/test/test.go
+++ b/pkg/commands/test/test.go
@@ -68,7 +68,7 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 				update.NewUpdateCommand().Run(cmd, fileList)
 			}
 
-			compiler, err := policy.BuildCompiler(viper.GetString("policy"))
+			compiler, err := policy.BuildCompiler(viper.GetString("policy"), false)
 			if err != nil {
 				log.G(ctx).Fatalf("Problem building rego compiler: %s", err)
 			}

--- a/pkg/commands/test/test_test.go
+++ b/pkg/commands/test/test_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/instrumenta/conftest/pkg/parser/docker"
 	"github.com/instrumenta/conftest/pkg/parser/yaml"
-    "github.com/instrumenta/conftest/pkg/policy"
+	"github.com/instrumenta/conftest/pkg/policy"
 
 	"github.com/spf13/viper"
 )
@@ -202,7 +202,7 @@ metadata:
 		t.Fatalf("Could not unmarshal yaml")
 	}
 
-	compiler, err := policy.BuildCompiler("testdata/policy/test_policy.rego")
+	compiler, err := policy.BuildCompiler("testdata/policy/test_policy.rego", false)
 	if err != nil {
 		t.Fatalf("Could not build rego compiler")
 	}
@@ -240,7 +240,7 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 		t.Fatalf("Could not unmarshal dockerfile")
 	}
 
-	compiler, err := policy.BuildCompiler("testdata/policy/test_policy_dockerfile.rego")
+	compiler, err := policy.BuildCompiler("testdata/policy/test_policy_dockerfile.rego", false)
 	if err != nil {
 		t.Fatalf("Could not build rego compiler")
 	}

--- a/pkg/commands/verify/verify.go
+++ b/pkg/commands/verify/verify.go
@@ -1,14 +1,14 @@
 package verify
 
 import (
-	"path/filepath"
-	"fmt"
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/instrumenta/conftest/pkg/commands/test"
 	"github.com/instrumenta/conftest/pkg/constants"
 	"github.com/instrumenta/conftest/pkg/policy"
-	"github.com/instrumenta/conftest/pkg/commands/test"
 
 	"github.com/containerd/containerd/log"
 	"github.com/open-policy-agent/opa/tester"
@@ -19,20 +19,20 @@ import (
 func NewVerifyCommand(getOutputManager func() test.OutputManager) *cobra.Command {
 	ctx := context.Background()
 	cmd := &cobra.Command{
-		Use:   "verify",
-		Short: "Verify Rego unit tests",
+		Use:     "verify",
+		Short:   "Verify Rego unit tests",
 		Version: fmt.Sprintf("Version: %s\nCommit: %s\nDate: %s\n", constants.Version, constants.Commit, constants.Date),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			err := viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 			if err != nil {
 				log.G(ctx).Fatal("Failed to bind argument:", err)
-			}		
+			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			out := getOutputManager()
 
 			policyPath := viper.GetString("policy")
-			compiler, err := policy.BuildCompiler(policyPath)
+			compiler, err := policy.BuildCompiler(policyPath, true)
 			if err != nil {
 				log.G(ctx).Fatalf("Problem building rego compiler: %s", err)
 			}
@@ -51,9 +51,9 @@ func NewVerifyCommand(getOutputManager func() test.OutputManager) *cobra.Command
 				msg := fmt.Errorf("%s", result.Msg)
 				fileName := filepath.Join(policyPath, result.FileName)
 				if result.Fail {
-					err = out.Put(fileName, test.CheckResult{Failures:[]error{msg}})
+					err = out.Put(fileName, test.CheckResult{Failures: []error{msg}})
 				} else {
-					err = out.Put(fileName, test.CheckResult{Successes:[]error{msg}})
+					err = out.Put(fileName, test.CheckResult{Successes: []error{msg}})
 				}
 
 				if err != nil {
@@ -78,7 +78,7 @@ func NewVerifyCommand(getOutputManager func() test.OutputManager) *cobra.Command
 type report struct {
 	FileName string
 	Msg      string
-	Fail 	bool
+	Fail     bool
 }
 
 func getResults(ctx context.Context, in <-chan *tester.Result) <-chan report {
@@ -89,7 +89,7 @@ func getResults(ctx context.Context, in <-chan *tester.Result) <-chan report {
 			if result.Error != nil {
 				log.G(ctx).Fatalf("Test failed to execute: %s", result.Error)
 			}
-			msg := result.Package+"."+result.Name
+			msg := result.Package + "." + result.Name
 			results <- report{FileName: result.Location.File, Msg: msg, Fail: result.Fail}
 		}
 	}()

--- a/pkg/policy/compiler.go
+++ b/pkg/policy/compiler.go
@@ -11,8 +11,8 @@ import (
 
 // BuildCompiler compiles all Rego policies at the given path and returns the Compiler containing
 // the compilation state
-func BuildCompiler(path string) (*ast.Compiler, error) {
-	files, err := recursivelySearchDirForRegoFiles(path)
+func BuildCompiler(path string, withTests bool) (*ast.Compiler, error) {
+	files, err := recursivelySearchDirForRegoFiles(path, withTests)
 	if err != nil {
 		return nil, err
 	}
@@ -43,15 +43,23 @@ func BuildCompiler(path string) (*ast.Compiler, error) {
 	return compiler, nil
 }
 
-func recursivelySearchDirForRegoFiles(path string) ([]string, error) {
+func recursivelySearchDirForRegoFiles(path string, withTests bool) ([]string, error) {
 	var filepaths []string
+
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".rego") {
-			filepaths = append(filepaths, path)
+		if withTests {
+			if !info.IsDir() && strings.HasSuffix(info.Name(), ".rego") {
+				filepaths = append(filepaths, path)
+			}
+		} else {
+			if !info.IsDir() && strings.HasSuffix(info.Name(), ".rego") && !strings.HasSuffix(info.Name(), "_test.rego") {
+				filepaths = append(filepaths, path)
+			}
+
 		}
 
 		return nil


### PR DESCRIPTION
A fix of sorts for the issue reported in #114. I'm a golang newbie, so this might not be the best way of attacking this problem but it has yielded the results that I'm after (not loading the `*_test.rego` files when running a `conftest test`).