### PR TITLE
Use relative path on compiling policies

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -69,6 +69,16 @@
   [ "$status" -eq 1 ]
 }
 
+@test "Can parse nested files with name overlap (first)" {
+  run ./conftest test -p examples/nested/policy --namespace group1 examples/nested/data.json
+  [ "$status" -eq 1 ]
+}
+
+@test "Can parse nested files with name overlap (second)" {
+  run ./conftest test -p examples/nested/policy --namespace group2 examples/nested/data.json
+  [ "$status" -eq 1 ]
+}
+
 @test "Can parse cue files" {
   run ./conftest test -p examples/cue/policy examples/cue/deployment.cue
   [ "$status" -eq 1 ]

--- a/examples/nested/data.json
+++ b/examples/nested/data.json
@@ -1,0 +1,3 @@
+{
+    "hello": "world"
+}

--- a/examples/nested/policy/group1/main.rego
+++ b/examples/nested/policy/group1/main.rego
@@ -1,0 +1,6 @@
+package group1
+
+deny[msg] {
+  input.hello = "world"
+  msg = "nested json group1 failed"
+}

--- a/examples/nested/policy/group2/main.rego
+++ b/examples/nested/policy/group2/main.rego
@@ -1,0 +1,6 @@
+package group2
+
+deny[msg] {
+  input.hello = "world"
+  msg = "nested json group2 failed"
+}

--- a/pkg/policy/compiler.go
+++ b/pkg/policy/compiler.go
@@ -25,12 +25,17 @@ func BuildCompiler(path string, withTests bool) (*ast.Compiler, error) {
 			return nil, err
 		}
 
-		name := filepath.Base(file)
-		parsed, err := ast.ParseModule(name, string(out[:]))
+		relPath, err := filepath.Rel(path, file)
 		if err != nil {
 			return nil, err
 		}
-		modules[name] = parsed
+
+		parsed, err := ast.ParseModule(relPath, string(out[:]))
+		if err != nil {
+			return nil, err
+		}
+
+		modules[relPath] = parsed
 	}
 
 	compiler := ast.NewCompiler()


### PR DESCRIPTION
This resolves #117 where duplicate file names overwrite each others policies.