### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ package main
 
 
 deny[msg] {
-  input.kind = "Deployment"
   deployment := input["deployment.yaml"]["spec"]["selector"]["matchLabels"]["app"]
   service := input["service.yaml"]["spec"]["selector"]["app"]
   


### PR DESCRIPTION
minor README.md fix

output without `input.kind = "Deployment"`
```
> conftest test --combine-config deployment.yaml service.yaml --trace
Enter data.main.deny = _
| Eval data.main.deny = _
| Index data.main.deny = _ (matched 1 rule)
| Enter data.main.deny
| | Eval __local0__ = input["deployment.yaml"].spec.selector.matchLabels.app
| | Eval __local1__ = input["service.yaml"].spec.selector.app
| | Eval neq(__local0__, __local1__)
| | Eval sprintf("Expected these values to be the same but received %v for deployment and %v for service", [__local0__, __local1__], __local2__)
| | Eval msg = __local2__
| | Exit data.main.deny
| Redo data.main.deny
| | Redo msg = __local2__
| | Redo sprintf("Expected these values to be the same but received %v for deployment and %v for service", [__local0__, __local1__], __local2__)
| | Redo neq(__local0__, __local1__)
| | Redo __local1__ = input["service.yaml"].spec.selector.app
| | Redo __local0__ = input["deployment.yaml"].spec.selector.matchLabels.app
| Exit data.main.deny = _
Redo data.main.deny = _
| Redo data.main.deny = _
FAIL - Combined-configs (multi-file) - Expected these values to be the same but received hello-kubernetes for deployment and goodbye-kubernetes for service
```
output with `input.kind = "Deployment"`
```
> conftest test --combine-config deployment.yaml service.yaml --trace
Enter data.main.deny = _
| Eval data.main.deny = _
| Index data.main.deny = _ matched 0 rules)
| Exit data.main.deny = _
Redo data.main.deny = _
| Redo data.main.deny = _
```
issue related to this change: https://github.com/instrumenta/conftest/issues/128