### PR TITLE
Remove viper dependency on Download

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -66,9 +66,9 @@ func NewDefaultCommand() *cobra.Command {
 	cmd.AddCommand(parse.NewParseCommand(
 		os.Exit,
 	))
-	cmd.AddCommand(update.NewUpdateCommand())
+	cmd.AddCommand(update.NewUpdateCommand(ctx))
 	cmd.AddCommand(push.NewPushCommand(ctx, logger))
-	cmd.AddCommand(pull.NewPullCommand())
+	cmd.AddCommand(pull.NewPullCommand(ctx))
 	cmd.AddCommand(verify.NewVerifyCommand(
 		test.GetOutputManager,
 	))

--- a/commands/pull/pull.go
+++ b/commands/pull/pull.go
@@ -2,34 +2,37 @@ package pull
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 
 	"github.com/instrumenta/conftest/policy"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-// NewPullCommand creates a new pull command
-func NewPullCommand() *cobra.Command {
-	cmd := &cobra.Command{
+// NewPullCommand creates a new pull command to allow users
+// to download individual policies
+func NewPullCommand(ctx context.Context) *cobra.Command {
+	cmd := cobra.Command{
 		Use:   "pull <repository>",
 		Short: "Download individual policies",
 		Long:  `Download individual policies from a registry`,
 		Args:  cobra.MinimumNArgs(1),
 
-		Run: func(cmd *cobra.Command, args []string) {
-			RunPullCommand(args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			policyDir := filepath.Join(".", viper.GetString("policy"))
+			policies := getPolicies(args)
+
+			if err := policy.Download(ctx, policyDir, policies); err != nil {
+				return fmt.Errorf("download policies: %w", err)
+			}
+
+			return nil
 		},
 	}
 
-	return cmd
-}
-
-// RunPullCommand runs the pull command
-func RunPullCommand(repositories []string) {
-	policies := getPolicies(repositories)
-
-	ctx := context.Background()
-	policy.Download(ctx, policies)
+	return &cmd
 }
 
 func getPolicies(repositories []string) []policy.Policy {

--- a/commands/pull/pull_test.go
+++ b/commands/pull/pull_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestPoliciesToPull(t *testing.T) {
-
 	repositories := []string{
 		"my.url.com/repository",
 		"my.url.com/repository:v1",

--- a/commands/test/test.go
+++ b/commands/test/test.go
@@ -62,7 +62,7 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 			}
 
 			if viper.GetBool("update") {
-				update.NewUpdateCommand().Run(cmd, fileList)
+				update.NewUpdateCommand(ctx).Run(cmd, fileList)
 			}
 
 			policyPath := viper.GetString("policy")


### PR DESCRIPTION
Currently the `Download` method requires `viper` to resolve where to download the policies to. From a library standpoint, viper shouldn't really be in the mix, but rather give the consumer the ability to choose where to put their policies.