### PR TITLE
Fix kubernetes policy example

### DIFF
--- a/examples/kubernetes/policy/base_test.rego
+++ b/examples/kubernetes/policy/base_test.rego
@@ -1,6 +1,5 @@
 package main
 
-
 empty(value) {
   count(value) == 0
 }
@@ -13,14 +12,12 @@ no_warnings {
   empty(warn)
 }
 
-
-
 test_deployment_without_security_context {
   deny["Containers must not run as root in Deployment sample"] with input as {"kind": "Deployment", "metadata": { "name": "sample" }}
 }
 
 test_deployment_with_security_context {
-  no_violations with input as {"kind": "Deployment", "spec": {
+  no_violations with input as {"kind": "Deployment", "metadata": {"name": "sample"}, "spec": {
     "selector": { "matchLabels": { "app": "something", "release": "something" }},
     "template": { "spec": { "securityContext": { "runAsNonRoot": true  }}}}}
 }

--- a/examples/kubernetes/policy/deny.rego
+++ b/examples/kubernetes/policy/deny.rego
@@ -6,7 +6,8 @@ name = input.metadata.name
 
 deny[msg] {
   kubernetes.is_deployment
-  not input.spec.template.spec.securityContext.runAsNonRoot = true
+  not input.spec.template.spec.securityContext.runAsNonRoot
+
   msg = sprintf("Containers must not run as root in Deployment %s", [name])
 }
 
@@ -18,5 +19,6 @@ labels {
 deny[msg] {
   kubernetes.is_deployment
   not labels
+
   msg = sprintf("Deployment %s must provide app/release labels for pod selectors", [name])
 }


### PR DESCRIPTION
If a property doesn't exist on the `input` for Rego, the result is undefined. This cascades into sprintf() being undefined, into msg being undefined, making the policy never be able to fail.

This fixes up our example a little bit