### PR TITLE
Handle explicitly blank filenames passed into conftest

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -5,6 +5,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Not fail when passed an explicit blank filename" {
+  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml ""
+  [ "$status" -eq 0 ]
+}
+
 @test "Fail when testing a deployment with root containers" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   [ "$status" -eq 1 ]

--- a/commands/test/test.go
+++ b/commands/test/test.go
@@ -56,13 +56,22 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 			}
 		},
 		Run: func(cmd *cobra.Command, fileList []string) {
-			if len(fileList) < 1 {
+
+			// Remove any blank files from the array
+			var nonBlankFileList []string
+			for _, name := range fileList {
+				if name != "" {
+					nonBlankFileList = append(nonBlankFileList, name)
+				}
+			}
+
+			if len(nonBlankFileList) < 1 {
 				cmd.SilenceErrors = true
 				log.G(ctx).Fatal("The first argument should be a file")
 			}
 
 			if viper.GetBool("update") {
-				update.NewUpdateCommand(ctx).Run(cmd, fileList)
+				update.NewUpdateCommand(ctx).Run(cmd, nonBlankFileList)
 			}
 
 			policyPath := viper.GetString("policy")
@@ -76,7 +85,7 @@ func NewTestCommand(osExit func(int), getOutputManager func() OutputManager) *co
 				log.G(ctx).Fatalf("build rego compiler: %s", err)
 			}
 
-			configurations, err := GetConfigurations(ctx, fileList)
+			configurations, err := GetConfigurations(ctx, nonBlankFileList)
 			if err != nil {
 				osExit(1)
 			}


### PR DESCRIPTION
Currently when a blank filename is passed to conftest, for example with
`conftest test ""` we try and open blank and fail with an odd error.

This change means we ignore explicit blank files passed in.

This hit me with the GitHub Action, due to the variadic nature of
passing files to conftest. GitHub Actions doesn't have a good optional
argument pattern, and passes "" explicitly. This change hits an edge
case for typical usage, but opens up the ability for the Action to take
arbitrary arguments.