### PR TITLE
Lowercase keys in JSON output

### DIFF
--- a/commands/test/output.go
+++ b/commands/test/output.go
@@ -103,9 +103,9 @@ func (s *stdOutputManager) Flush() error {
 
 type jsonCheckResult struct {
 	Filename string   `json:"filename"`
-	Warnings []string `json:"Warnings"`
-	Failures []string `json:"Failures"`
-	Successes []string `json:"Successes"`
+	Warnings []string `json:"warnings"`
+	Failures []string `json:"failures"`
+	Successes []string `json:"successes"`
 }
 
 // jsonOutputManager reports `conftest` results to `stdout` as a json array..

--- a/commands/test/output_test.go
+++ b/commands/test/output_test.go
@@ -85,9 +85,9 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			exp: `[
 	{
 		"filename": "examples/kubernetes/service.yaml",
-		"Warnings": [],
-		"Failures": [],
-		"Successes": []
+		"warnings": [],
+		"failures": [],
+		"successes": []
 	}
 ]
 `,
@@ -104,13 +104,13 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			exp: `[
 	{
 		"filename": "examples/kubernetes/service.yaml",
-		"Warnings": [
+		"warnings": [
 			"first warning"
 		],
-		"Failures": [
+		"failures": [
 			"first failure"
 		],
-		"Successes": []
+		"successes": []
 	}
 ]
 `,
@@ -126,11 +126,11 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			exp: `[
 	{
 		"filename": "examples/kubernetes/service.yaml",
-		"Warnings": [],
-		"Failures": [
+		"warnings": [],
+		"failures": [
 			"first failure"
 		],
-		"Successes": []
+		"successes": []
 	}
 ]
 `,
@@ -146,11 +146,11 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			exp: `[
 	{
 		"filename": "",
-		"Warnings": [],
-		"Failures": [
+		"warnings": [],
+		"failures": [
 			"first failure"
 		],
-		"Successes": []
+		"successes": []
 	}
 ]
 `,


### PR DESCRIPTION
Currently one of the keys `filename` is lowercase, the others are
Leading caps. This inconsistency makes working with the output harder,
as generators often assume some consistency, at least without
configuration.

Typically, JSON keys are snake_case or camelCase in my experience.
Especially outside Go, I don't think I ever see Uppercase key name.

The Google styleguide for instance recommends camelCase names:
https://google.github.io/styleguide/jsoncstyleguide.xml

This change makes all key names lowercase, which I think is a good
default. This breaks for anyone relying on the key names being
inconsistent today, but better to break today with fewer users than an
inconsistent API later with more users in my experience.