### PR TITLE
Add explicit WORKDIR to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ WORKDIR /examples
 FROM alpine:latest
 COPY --from=builder /app/conftest /
 RUN ln -s /conftest /usr/local/bin/conftest
+WORKDIR /project
 
 ENTRYPOINT ["/conftest"]
 CMD ["--help"]


### PR DESCRIPTION
This is required (and documented) when running conftest using Docker run
in order to have an explicit default to detect the mounted policy folder.