### PR TITLE
Remove yaml unmarshalling

### DIFF
--- a/commands/test/test.go
+++ b/commands/test/test.go
@@ -169,7 +169,11 @@ func GetConfigurations(ctx context.Context, fileList []string) (map[string]inter
 		})
 	}
 
-	configManager := parser.NewConfigManager(fileType)
+	configManager, err := parser.NewConfigManager(fileType)
+	if err != nil {
+		return nil, fmt.Errorf("create config manager: %w", err)
+	}
+
 	configurations, err := configManager.BulkUnmarshal(configFiles)
 	if err != nil {
 		log.G(ctx).Errorf("Unable to BulkUnmarshal your config files: %v", err)

--- a/parser/cue/cue.go
+++ b/parser/cue/cue.go
@@ -1,32 +1,36 @@
 package cue
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"cuelang.org/go/cue"
-	cFormat "cuelang.org/go/cue/format"
-	"github.com/ghodss/yaml"
+	cformat "cuelang.org/go/cue/format"
 )
 
 type Parser struct{}
 
 func (c *Parser) Unmarshal(p []byte, v interface{}) error {
-	var r cue.Runtime
-	out, err := cFormat.Source(p)
+	out, err := cformat.Source(p)
 	if err != nil {
-		return fmt.Errorf("error occured when formatting cue: %v", err)
+		return fmt.Errorf("format cue: %w", err)
 	}
+
+	var r cue.Runtime
 	instance, err := r.Compile("name", out)
 	if err != nil {
-		return fmt.Errorf("error occured parsing cue: %v", err)
+		return fmt.Errorf("compile cue: %w", err)
 	}
+
 	j, err := instance.Value().MarshalJSON()
 	if err != nil {
-		return fmt.Errorf("Unable to marshal cue config: %s", err)
+		return fmt.Errorf("marshal cue to json: %w", err)
 	}
-	err = yaml.Unmarshal(j, v)
+
+	err = json.Unmarshal(j, v)
 	if err != nil {
-		return fmt.Errorf("Unable to parse YAML cue-json: %s", err)
+		return fmt.Errorf("unmarshal cue json: %w", err)
 	}
+
 	return nil
 }

--- a/parser/cue/cue_test.go
+++ b/parser/cue/cue_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestCueParser(t *testing.T) {
-	parser := &Parser{}
 	p := `package kubernetes
 
 
@@ -21,7 +20,9 @@ func TestCueParser(t *testing.T) {
 			}]
 		}
 	}`
+
 	var input interface{}
+	parser := &Parser{}
 	err := parser.Unmarshal([]byte(p), &input)
 	if err != nil {
 		t.Fatalf("parser should not have thrown an error: %v", err)

--- a/parser/docker/docker.go
+++ b/parser/docker/docker.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
@@ -23,7 +22,7 @@ func (dp *Parser) Unmarshal(p []byte, v interface{}) error {
 	r := bytes.NewReader(p)
 	res, err := parser.Parse(r)
 	if err != nil {
-		return fmt.Errorf("Unable to parse Dockerfile from: %s", err)
+		return fmt.Errorf("parse dockerfile: %w", err)
 	}
 
 	// Code attributed to https://github.com/asottile/dockerfile
@@ -53,12 +52,11 @@ func (dp *Parser) Unmarshal(p []byte, v interface{}) error {
 
 	j, err := json.Marshal(dockerFile)
 	if err != nil {
-		return fmt.Errorf("Unable to marshal config: %s", err)
+		return fmt.Errorf("marshal dockerfile to json: %w", err)
 	}
 
-	err = yaml.Unmarshal(j, v)
-	if err != nil {
-		return fmt.Errorf("Unable to parse YAML from Docker-json: %s", err)
+	if err := json.Unmarshal(j, v); err != nil {
+		return fmt.Errorf("unmarshal dockerfile json: %w", err)
 	}
 
 	return nil

--- a/parser/hcl2/hcl2.go
+++ b/parser/hcl2/hcl2.go
@@ -4,37 +4,31 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 )
 
-type Parser struct {}
+type Parser struct{}
 
 func (h *Parser) Unmarshal(p []byte, v interface{}) error {
 	file, diags := hclsyntax.ParseConfig(p, "", hcl.Pos{Line: 1, Column: 1})
 
 	if diags.HasErrors() {
-		for _, diag := range diags {
-			fmt.Println(diag.Error())
-		}
-		return fmt.Errorf("Error occured while parsing HCL2 config")
+		return fmt.Errorf("parse hcl2 config: %s", diags.Error())
 	}
 
 	content, err := convertFile(file)
-
 	if err != nil {
-		return fmt.Errorf("Unable to convert config %s", err)
+		return fmt.Errorf("convert hcl2 to json: %w", err)
 	}
 
 	j, err := json.Marshal(content)
 	if err != nil {
-		return fmt.Errorf("Unable to marshal config: %s", err)
+		return fmt.Errorf("marshal hcl2 to json: %w", err)
 	}
 
-	err = yaml.Unmarshal(j, v)
-	if err != nil {
-		return fmt.Errorf("Unable to parse YAML from HCL-json: %s", err)
+	if err := json.Unmarshal(j, v); err != nil {
+		return fmt.Errorf("unmarshal hcl2 json: %w", err)
 	}
 
 	return nil

--- a/parser/ini/ini.go
+++ b/parser/ini/ini.go
@@ -4,35 +4,36 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/go-ini/ini"
 )
 
 type Parser struct{}
 
 func (i *Parser) Unmarshal(p []byte, v interface{}) error {
-	result := map[string]map[string]string{}
 	cfg, err := ini.Load(p)
 	if err != nil {
-		return fmt.Errorf("Fail to read ini file: %v", err)
+		return fmt.Errorf("read ini file: %w", err)
 	}
 
-	sections := cfg.Sections()
-	for _, s := range sections {
+	result := make(map[string]map[string]string)
+	for _, s := range cfg.Sections() {
 		sectionName := s.Name()
 		if sectionName == "DEFAULT" {
 			continue
 		}
+
 		result[sectionName] = map[string]string{}
 		result[sectionName] = s.KeysHash()
 	}
+
 	j, err := json.Marshal(result)
 	if err != nil {
-		return fmt.Errorf("Error trying to parse ini to json: %s", err)
+		return fmt.Errorf("marshal ini to json: %w", err)
 	}
-	err = yaml.Unmarshal(j, v)
-	if err != nil {
-		return fmt.Errorf("Unable to parse YAML from ini-json: %s", err)
+
+	if err := json.Unmarshal(j, v); err != nil {
+		return fmt.Errorf("unmarshal ini json: %w", err)
 	}
+
 	return nil
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -19,9 +19,12 @@ import (
 
 func TestUnmarshaller(t *testing.T) {
 	t.Run("we should be able to construct a unmarshaller for a type of file", func(t *testing.T) {
-		configManager := parser.NewConfigManager("yml")
-		t.Run("which can be used to BulkUnmarshal file contents into an object", func(t *testing.T) {
+		configManager, err := parser.NewConfigManager("yml")
+		if err != nil {
+			t.Fatalf("create config parser: %v", err)
+		}
 
+		t.Run("which can be used to BulkUnmarshal file contents into an object", func(t *testing.T) {
 			testTable := []struct {
 				name           string
 				controlReaders []parser.ConfigDoc

--- a/parser/terraform/terraform.go
+++ b/parser/terraform/terraform.go
@@ -1,9 +1,17 @@
 package terraform
 
-import "github.com/hashicorp/hcl"
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl"
+)
 
 type Parser struct{}
 
 func (s *Parser) Unmarshal(p []byte, v interface{}) error {
-	return hcl.Unmarshal(p, v)
+	if err := hcl.Unmarshal(p, v); err != nil {
+		return fmt.Errorf("unmarshal hcl: %w", err)
+	}
+
+	return nil
 }

--- a/parser/toml/toml.go
+++ b/parser/toml/toml.go
@@ -9,9 +9,8 @@ import (
 type Parser struct{}
 
 func (tp *Parser) Unmarshal(p []byte, v interface{}) error {
-	err := toml.Unmarshal(p, v)
-	if err != nil {
-		return fmt.Errorf("Unable to parse TOML: %s", err)
+	if err := toml.Unmarshal(p, v); err != nil {
+		return fmt.Errorf("unmarshal toml: %w", err)
 	}
 
 	return nil

--- a/parser/yaml/yaml.go
+++ b/parser/yaml/yaml.go
@@ -10,46 +10,52 @@ import (
 
 type Parser struct{}
 
-func (yp *Parser) separateSubDocuments(data []byte) [][]byte {
+func (yp *Parser) Unmarshal(p []byte, v interface{}) error {
+	subDocuments := separateSubDocuments(p)
+	if len(subDocuments) > 1 {
+		if err := unmarshalMultipleDocuments(subDocuments, v); err != nil {
+			return fmt.Errorf("unmarshal multiple documents: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := yaml.Unmarshal(p, v); err != nil {
+		return fmt.Errorf("unmarshal yaml: %w", err)
+	}
+
+	return nil
+}
+
+func separateSubDocuments(data []byte) [][]byte {
 	linebreak := "\n"
 	windowsLineEnding := bytes.Contains(data, []byte("\r\n"))
 	if windowsLineEnding && runtime.GOOS == "windows" {
 		linebreak = "\r\n"
 	}
+
 	return bytes.Split(data, []byte(linebreak+"---"+linebreak))
 }
 
-func (yp *Parser) unmarshalMultipleDocuments(subDocuments [][]byte, v interface{}) error {
+func unmarshalMultipleDocuments(subDocuments [][]byte, v interface{}) error {
 	var documentStore []interface{}
 	for _, subDocument := range subDocuments {
 		var documentObject interface{}
-		err := yaml.Unmarshal(subDocument, &documentObject)
-		if err != nil {
-			return fmt.Errorf("Unable to parse YAML: %s", err)
+		if err := yaml.Unmarshal(subDocument, &documentObject); err != nil {
+			return fmt.Errorf("unmarshal subdocument yaml: %w", err)
 		}
+
 		documentStore = append(documentStore, documentObject)
 	}
 
 	yamlConfigBytes, err := yaml.Marshal(documentStore)
 	if err != nil {
-		return fmt.Errorf("Unable to marshal documentStore %v: %s", documentStore, err)
-	}
-	err = yaml.Unmarshal(yamlConfigBytes, v)
-	if err != nil {
-		return fmt.Errorf("Unable to Unmarshal yamlConfigBytes %s: %s", string(yamlConfigBytes), err)
-	}
-	return nil
-}
-
-func (yp *Parser) Unmarshal(p []byte, v interface{}) error {
-	subDocuments := yp.separateSubDocuments(p)
-	if len(subDocuments) > 1 {
-		return yp.unmarshalMultipleDocuments(subDocuments, v)
+		return fmt.Errorf("marshal yaml document: %w", err)
 	}
 
-	err := yaml.Unmarshal(p, v)
-	if err != nil {
-		return fmt.Errorf("Unable to Unmarshal yamlConfigBytes %s: %s", string(p), err)
+	if err := yaml.Unmarshal(yamlConfigBytes, v); err != nil {
+		return fmt.Errorf("unmarshal yaml: %w", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
Just a little cleanup task I've been meaning to put together. Noticed that we're using the `yaml` package in most of our parsers for Unmarshal, but json makes more sense as we're initially marshalling into json.