### PR TITLE
migrate GetConfigurations() to parser package

### DIFF
--- a/commands/parse/parse.go
+++ b/commands/parse/parse.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/instrumenta/conftest/commands/test"
 	"github.com/instrumenta/conftest/parser"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,7 +27,7 @@ func NewParseCommand(ctx context.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, fileList []string) error {
-			out, err := parseInput(ctx, fileList)
+			out, err := parseInput(ctx, viper.GetString("input"), fileList)
 			if err != nil {
 				return fmt.Errorf("failed during parser process: %w", err)
 			}
@@ -42,8 +41,8 @@ func NewParseCommand(ctx context.Context) *cobra.Command {
 	return &cmd
 }
 
-func parseInput(ctx context.Context, fileList []string) (string, error) {
-	configurations, err := test.GetConfigurations(ctx, fileList)
+func parseInput(ctx context.Context, input string, fileList []string) (string, error) {
+	configurations, err := parser.GetConfigurations(ctx, input, fileList)
 	if err != nil {
 		return "", fmt.Errorf("calling the parser method: %w", err)
 	}

--- a/commands/parse/parse_test.go
+++ b/commands/parse/parse_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-
-	"github.com/spf13/viper"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -77,13 +75,10 @@ func TestInputFlagForparseInput(t *testing.T) {
 		}
 	}
 }`
-		viper.Reset()
-		viper.Set("input", testunit.input)
-		actual, err := parseInput(ctx, testunit.fileList)
+		actual, err := parseInput(ctx, testunit.input, testunit.fileList)
 		if err != nil {
 			t.Fatalf("parsing input: %v", err)
 		}
-		viper.Reset()
 
 		if !strings.Contains(actual, expected) {
 			t.Errorf("unexpected parsed input. expected %v actual %v", expected, actual)
@@ -123,7 +118,7 @@ func TestParseOutputwithNoFlag(t *testing.T) {
 	},
 	`
 	t.Run(unit.name, func(t *testing.T) {
-		actual, err := parseInput(ctx, unit.fileList)
+		actual, err := parseInput(ctx, "", unit.fileList)
 		if err != nil {
 			t.Fatalf("parsing input: %v", err)
 		}

--- a/parser/config.go
+++ b/parser/config.go
@@ -1,0 +1,94 @@
+package parser
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GetConfigurations parses and returns the configurations given in the file list
+func GetConfigurations(ctx context.Context, input string, fileList []string) (map[string]interface{}, error) {
+	var configFiles []ConfigDoc
+	var fileType string
+
+	for _, fileName := range fileList {
+		var err error
+		var config io.ReadCloser
+
+		fileType, err = getFileType(input, fileName)
+		if err != nil {
+			return nil, fmt.Errorf("get file type: %w", err)
+		}
+
+		config, err = getConfig(fileName)
+		if err != nil {
+			return nil, fmt.Errorf("get config: %w", err)
+		}
+
+		configFiles = append(configFiles, ConfigDoc{
+			ReadCloser: config,
+			Filepath:   fileName,
+		})
+	}
+
+	configManager, err := NewConfigManager(fileType)
+	if err != nil {
+		return nil, fmt.Errorf("create config manager: %w", err)
+	}
+
+	configurations, err := configManager.BulkUnmarshal(configFiles)
+	if err != nil {
+		return nil, fmt.Errorf("bulk unmarshal: %w", err)
+	}
+
+	return configurations, nil
+
+}
+
+func getConfig(fileName string) (io.ReadCloser, error) {
+	if fileName == "-" {
+		config := ioutil.NopCloser(bufio.NewReader(os.Stdin))
+		return config, nil
+	}
+
+	filePath, err := filepath.Abs(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("get abs: %w", err)
+	}
+
+	config, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+
+	return config, nil
+}
+
+func getFileType(inputFileType, fileName string) (string, error) {
+	if inputFileType != "" {
+		return inputFileType, nil
+	}
+
+	if fileName == "-" && inputFileType == "" {
+		return "yaml", nil
+	}
+
+	if fileName != "-" {
+		fileType := ""
+		if strings.Contains(fileName, ".") {
+			fileType = strings.TrimPrefix(filepath.Ext(fileName), ".")
+		} else {
+			ss := strings.SplitAfter(fileName, "/")
+			fileType = ss[len(ss)-1]
+		}
+
+		return fileType, nil
+	}
+
+	return "", fmt.Errorf("unsupported file type")
+}


### PR DESCRIPTION
Currently, we are calling `GetConfigurations()` in `parse` and `test` command both. (`test` command owns that. I dunno why?)

The dependency on `viper` in this function, cause us passing input flag in test which does not look like a good pattern like in `parse_test.go`
```go
viper.Reset()
viper.Set("input", testunit.input)
....
viper.Reset()
```

Rather than calling functions between subcommands, it would be better we place it in the `parser` package because it more looks like it is a part of the parsing process.

This PR:
- removes `viper` dependencies from `parser_test.go`.
- moves file configs and functions to inside `parser` package.

For the next step, we can write tests against `config.go`.