### PR TITLE
Move commands to internal

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
   ignore:
   - goarch: 386
   ldflags:
-  - -s -w -X github.com/instrumenta/conftest/commands.version={{.Version}} -X github.com/instrumenta/conftest/commands.commit={{.ShortCommit}} -X github.com/instrumenta/conftest/commands.date={{.Date}}
+  - -s -w -X github.com/instrumenta/conftest/internal/commands.version={{.Version}} -X github.com/instrumenta/conftest/internal/commands.commit={{.ShortCommit}} -X github.com/instrumenta/conftest/internal/commands.date={{.Date}}
 archives:
 - replacements:
     darwin: Darwin

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -7,12 +7,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/instrumenta/conftest/commands/parse"
-	"github.com/instrumenta/conftest/commands/pull"
-	"github.com/instrumenta/conftest/commands/push"
-	"github.com/instrumenta/conftest/commands/test"
-	"github.com/instrumenta/conftest/commands/update"
-	"github.com/instrumenta/conftest/commands/verify"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -55,12 +49,12 @@ func NewDefaultCommand() *cobra.Command {
 		}
 	}
 
-	cmd.AddCommand(test.NewTestCommand(ctx))
-	cmd.AddCommand(parse.NewParseCommand(ctx))
-	cmd.AddCommand(update.NewUpdateCommand(ctx))
-	cmd.AddCommand(push.NewPushCommand(ctx, logger))
-	cmd.AddCommand(pull.NewPullCommand(ctx))
-	cmd.AddCommand(verify.NewVerifyCommand(ctx))
+	cmd.AddCommand(NewTestCommand(ctx))
+	cmd.AddCommand(NewParseCommand(ctx))
+	cmd.AddCommand(NewUpdateCommand(ctx))
+	cmd.AddCommand(NewPushCommand(ctx, logger))
+	cmd.AddCommand(NewPullCommand(ctx))
+	cmd.AddCommand(NewVerifyCommand(ctx))
 
 	return &cmd
 }

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -1,4 +1,4 @@
-package test
+package commands
 
 import (
 	"bytes"
@@ -11,19 +11,18 @@ import (
 	"github.com/spf13/viper"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 const (
-	OutputSTD  = "stdout"
-	OutputJSON = "json"
-	OutputTAP  = "tap"
+	outputSTD  = "stdout"
+	outputJSON = "json"
+	outputTAP  = "tap"
 )
 
 // ValidOutputs returns the available output formats for reporting tests
 func ValidOutputs() []string {
 	return []string{
-		OutputSTD,
-		OutputJSON,
-		OutputTAP,
+		outputSTD,
+		outputJSON,
+		outputTAP,
 	}
 }
 
@@ -32,11 +31,11 @@ func GetOutputManager() OutputManager {
 	color := !viper.GetBool("no-color")
 
 	switch outFmt {
-	case OutputSTD:
+	case outputSTD:
 		return NewDefaultStdOutputManager(color)
-	case OutputJSON:
+	case outputJSON:
 		return NewDefaultJSONOutputManager()
-	case OutputTAP:
+	case outputTAP:
 		return NewDefaultTAPOutputManager()
 	default:
 		return NewDefaultStdOutputManager(color)

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -1,4 +1,4 @@
-package test
+package commands
 
 import (
 	"bytes"
@@ -185,17 +185,17 @@ func TestSupportedOutputManagers(t *testing.T) {
 	}{
 		{
 			name:          "std output should exist",
-			outputFormat:  OutputSTD,
+			outputFormat:  outputSTD,
 			outputManager: NewDefaultStdOutputManager(true),
 		},
 		{
 			name:          "json output should exist",
-			outputFormat:  OutputJSON,
+			outputFormat:  outputJSON,
 			outputManager: NewDefaultJSONOutputManager(),
 		},
 		{
 			name:          "tap output should exist",
-			outputFormat:  OutputTAP,
+			outputFormat:  outputTAP,
 			outputManager: NewDefaultTAPOutputManager(),
 		},
 		{

--- a/internal/commands/parse.go
+++ b/internal/commands/parse.go
@@ -1,4 +1,4 @@
-package parse
+package commands
 
 import (
 	"bytes"

--- a/internal/commands/parse_test.go
+++ b/internal/commands/parse_test.go
@@ -1,4 +1,4 @@
-package parse
+package commands
 
 import (
 	"strings"

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -1,4 +1,4 @@
-package pull
+package commands
 
 import (
 	"context"

--- a/internal/commands/pull_test.go
+++ b/internal/commands/pull_test.go
@@ -1,4 +1,4 @@
-package pull
+package commands
 
 import (
 	"reflect"

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -1,4 +1,4 @@
-package push
+package commands
 
 import (
 	"context"

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -1,4 +1,4 @@
-package test
+package commands
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/instrumenta/conftest/commands/update"
 	"github.com/instrumenta/conftest/parser"
 	"github.com/instrumenta/conftest/policy"
 	"github.com/open-policy-agent/opa/ast"
@@ -66,7 +65,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 			}
 
 			if viper.GetBool("update") {
-				update.NewUpdateCommand(ctx).Run(cmd, nonBlankFileList)
+				NewUpdateCommand(ctx).Run(cmd, nonBlankFileList)
 			}
 
 			policyPath := viper.GetString("policy")

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -1,4 +1,4 @@
-package test
+package commands
 
 import (
 	"context"

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -1,4 +1,4 @@
-package update
+package commands
 
 import (
 	"context"

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -1,11 +1,10 @@
-package verify
+package commands
 
 import (
 	"context"
 	"fmt"
 	"path/filepath"
 
-	"github.com/instrumenta/conftest/commands/test"
 	"github.com/instrumenta/conftest/policy"
 	"github.com/open-policy-agent/opa/tester"
 	"github.com/spf13/cobra"
@@ -27,7 +26,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			outputManager := test.GetOutputManager()
+			outputManager := GetOutputManager()
 			policyPath := viper.GetString("policy")
 
 			results, err := runVerification(ctx, policyPath)
@@ -49,12 +48,12 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("output format for conftest results - valid options are: %s", test.ValidOutputs()))
+	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("output format for conftest results - valid options are: %s", ValidOutputs()))
 
 	return &cmd
 }
 
-func runVerification(ctx context.Context, path string) ([]test.CheckResult, error) {
+func runVerification(ctx context.Context, path string) ([]CheckResult, error) {
 	regoFiles, err := policy.ReadFilesWithTests(path)
 	if err != nil {
 		return nil, fmt.Errorf("read rego test files: %s", err)
@@ -71,7 +70,7 @@ func runVerification(ctx context.Context, path string) ([]test.CheckResult, erro
 		return nil, fmt.Errorf("running tests: %w", err)
 	}
 
-	var results []test.CheckResult
+	var results []CheckResult
 	for result := range ch {
 		msg := fmt.Errorf("%s", result.Package+"."+result.Name)
 		fileName := filepath.Join(path, result.Location.File)
@@ -85,7 +84,7 @@ func runVerification(ctx context.Context, path string) ([]test.CheckResult, erro
 			success = []error{msg}
 		}
 
-		result := test.CheckResult{
+		result := CheckResult{
 			FileName:  fileName,
 			Successes: success,
 			Failures:  failure,

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/instrumenta/conftest/commands"
+	"github.com/instrumenta/conftest/internal/commands"
 )
 
 func main() {


### PR DESCRIPTION
Now that the commands no longer have specific `testdata` folders, we can move all of the commands to `internal`.