### PR TITLE
Add successes output

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -145,7 +145,7 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 3 ]
+  [ "$count" -eq 5 ]
 }
 
 @test "Can verify rego tests" {

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -145,7 +145,7 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 5 ]
+  [ "$count" -eq 4 ]
 }
 
 @test "Can verify rego tests" {

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -203,7 +203,7 @@ func runRules(ctx context.Context, namespace string, input interface{}, regex *r
 		if regex != nil {
 			totalErrors = append(totalErrors, errors...)
 		} else {
-			errors := []error{fmt.Errorf("passed rule %s", rule)}
+			errors := []error{fmt.Errorf("rule %s", rule)}
 			totalErrors = append(totalErrors, errors...)
 		}
 	}

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -201,7 +201,7 @@ func runRules(ctx context.Context, namespace string, input interface{}, regex *r
 		}
 
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		totalErrors = append(totalErrors, errors...)
@@ -246,7 +246,7 @@ func runMultipleQueries(ctx context.Context, query string, inputs interface{}, c
 	for _, input := range inputs.([]interface{}) {
 		violations, successes, traces, err := runQuery(ctx, query, input, compiler)
 		if err != nil {
-			return nil, nil, fmt.Errorf("run query: %w", err)
+			return nil, nil, nil, fmt.Errorf("run query: %w", err)
 		}
 
 		totalViolations = append(totalViolations, violations...)

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -144,23 +144,23 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 
 // GetResult returns the result of testing the structured data against their policies
 func GetResult(ctx context.Context, namespace string, input interface{}, compiler *ast.Compiler) (CheckResult, error) {
-	var successes []error
-	warnings, warnSuccesses, err := runRules(ctx, namespace, input, warnQ, compiler)
+	var totalSuccesses []error
+	warnings, successes, err := runRules(ctx, namespace, input, warnQ, compiler)
 	if err != nil {
 		return CheckResult{}, err
 	}
-	successes = append(successes, warnSuccesses...)
+	totalSuccesses = append(successes, successes...)
 
-	failures, failureSuccesses, err := runRules(ctx, namespace, input, denyQ, compiler)
+	failures, successes, err := runRules(ctx, namespace, input, denyQ, compiler)
 	if err != nil {
 		return CheckResult{}, err
 	}
-	successes = append(successes, failureSuccesses...)
+	totalSuccesses = append(successes, successes...)
 
 	result := CheckResult{
 		Warnings:  warnings,
 		Failures:  failures,
-		Successes: successes,
+		Successes: totalSuccesses,
 	}
 
 	return result, nil

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -149,13 +149,13 @@ func GetResult(ctx context.Context, namespace string, input interface{}, compile
 	if err != nil {
 		return CheckResult{}, err
 	}
-	totalSuccesses = append(successes, successes...)
+	totalSuccesses = append(totalSuccesses, successes...)
 
 	failures, successes, err := runRules(ctx, namespace, input, denyQ, compiler)
 	if err != nil {
 		return CheckResult{}, err
 	}
-	totalSuccesses = append(successes, successes...)
+	totalSuccesses = append(totalSuccesses, successes...)
 
 	result := CheckResult{
 		Warnings:  warnings,

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/instrumenta/conftest/parser/docker"
@@ -95,11 +96,19 @@ metadata:
 		t.Fatalf("could not process policy file: %s", err)
 	}
 
-	const expected = 2
-	actual := len(results.Failures)
-	if actual != expected {
-		t.Errorf("Multifile yaml test failure. Got %v failures, expected %v", actual, expected)
+	const expectedFailures = 2
+	actualFailures := len(results.Failures)
+	if actualFailures != expectedFailures {
+		t.Errorf("Multifile yaml test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
+
+	const expectedSuccesses = 1
+	actualSuccesses := len(results.Successes)
+	if actualSuccesses != expectedSuccesses {
+		t.Errorf("Multifile yaml test failure. Got %v success, expected %v", actualSuccesses, expectedSuccesses)
+	}
+
+	fmt.Println(len(results.Successes))
 }
 
 func TestDockerfile(t *testing.T) {
@@ -135,9 +144,15 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 		t.Fatalf("could not process policy file: %s", err)
 	}
 
-	const expected = 1
-	actual := len(results.Failures)
-	if actual != expected {
-		t.Errorf("Dockerfile test failure. Got %v failures, expected %v", actual, expected)
+	const expectedFailures = 1
+	actualFailures := len(results.Failures)
+	if actualFailures != expectedFailures {
+		t.Errorf("Dockerfile test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
+	}
+
+	const expectedSuccesses = 0
+	actualSuccesses := len(results.Successes)
+	if actualSuccesses != expectedSuccesses {
+		t.Errorf("Dockerfile test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
 	}
 }

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/instrumenta/conftest/parser/docker"
@@ -107,8 +106,6 @@ metadata:
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Multifile yaml test failure. Got %v success, expected %v", actualSuccesses, expectedSuccesses)
 	}
-
-	fmt.Println(len(results.Successes))
 }
 
 func TestDockerfile(t *testing.T) {


### PR DESCRIPTION
## What

* Add `Success` output

The example is here.

```
$ go run main.go test  my-file.hcl -p my-policy.rego -i hcl2
PASS - my-file.hcl - data.main.warn
PASS - my-file.hcl - data.main.deny
```

JSON output.

```
[
	{
		"filename": "my-file.hcl",
		"warnings": [],
		"failures": [],
		"successes": [
			"data.main.warn",
			"data.main.deny"
		]
	}
]
```

## Why

For https://github.com/instrumenta/conftest/issues/141

To improve feedback.

In current implementation there were no success output. 
Moreover, if all policy passes it will return almost empty output. This below is JSON output.

```
$ go run main.go test -o json my-file.hcl -p my-policy.rego -i hcl2

[
	{
		"filename": "my-file.hcl",
		"warnings": [],
		"failures": [],
		"successes": []
	}
]
```