### PR TITLE
conftest verify support `--trace` flag #111

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -47,8 +47,14 @@
   [ "$status" -eq 0 ]
 }
 
-@test "Has trace flag" {
+@test "Test command has trace flag" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --trace
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "data.kubernetes.is_service" ]]
+}
+
+@test "Verify command has trace flag" {
+    run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -79,7 +79,7 @@ func (s *stdOutputManager) Put(fileName string, cr CheckResult) error {
 		indicator = fmt.Sprintf(" - %s - ", fileName)
 	}
 
-	// print successes, warnings and then print errors
+	// print successes, warnings and then print errors and traces
 	for _, r := range cr.Successes {
 		s.logger.Print(s.color.Colorize("PASS", aurora.GreenFg), indicator, r)
 	}
@@ -90,6 +90,10 @@ func (s *stdOutputManager) Put(fileName string, cr CheckResult) error {
 
 	for _, r := range cr.Failures {
 		s.logger.Print(s.color.Colorize("FAIL", aurora.RedFg), indicator, r)
+	}
+
+	for _, r := range cr.Traces {
+		s.logger.Print(s.color.Colorize("TRAC", aurora.BlueFg), indicator, r)
 	}
 
 	return nil

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -30,6 +30,7 @@ type CheckResult struct {
 	Warnings  []error
 	Failures  []error
 	Successes []error
+	Traces    []*topdown.Event
 }
 
 // NewTestCommand creates a new test command


### PR DESCRIPTION
As per #111, I have enabled the `--trace` flag on the `verify` command.
Some of the major changes include the type `type CheckResult struct`,
which may or may not be to everyone's taste so happy to amend them on
feedback.