### PR TITLE
 Add exit status control for verify failures

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -163,3 +163,8 @@
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml examples/kubernetes/service.yaml
   [ "$status" -eq 1 ]
 }
+
+@test "Fail when unit test rego" {
+  run ./conftest verify -p examples/traefik/policy
+  [ "$status" -eq 1 ]
+}

--- a/examples/traefik/policy/base_test.rego
+++ b/examples/traefik/policy/base_test.rego
@@ -1,0 +1,5 @@
+package main
+
+test_ip_with_disallowed_ciphers {
+    deny["IPs should not use disallowed ciphers"] with input as {"entryPoints": {"http": {"tls": {"cipherSuites": ["TLS_RSA_WITH_AES_256_GCM_SHA384"]}}}}
+}

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/instrumenta/conftest/policy"
@@ -34,14 +35,23 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("running verification: %w", err)
 			}
 
+			var failures int
 			for _, result := range results {
 				if err := outputManager.Put(result.FileName, result); err != nil {
 					return fmt.Errorf("put result: %w", err)
+				}
+
+				if isResultFailure(result) {
+					failures++
 				}
 			}
 
 			if err := outputManager.Flush(); err != nil {
 				return fmt.Errorf("flushing output: %w", err)
+			}
+
+			if failures > 0 {
+				os.Exit(1)
 			}
 
 			return nil


### PR DESCRIPTION
## What

On failure for `verify` command, it should return `1` status code.
Same way as `test` command.

## Why

* #165 