### PR TITLE
Support EDN input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ As of today `conftest` supports:
 * CUE
 * Dockerfile
 * HCL2 (Experimental)
+* EDN
 
 Policies by default should be placed in a directory
 called `policy` but this can be overridden.
@@ -215,6 +216,7 @@ You can find examples using various other tools in the `examples` directory, inc
 * [TOML](examples/traefik)
 * [Dockerfile](examples/docker)
 * [HCL2](examples/hcl2)
+* [EDN](examples/edn)
 
 ## Configuration and external policies
 

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -74,6 +74,11 @@
   [ "$status" -eq 1 ]
 }
 
+@test "Can parse edn files" {
+  run ./conftest test -p examples/edn/policy examples/edn/sample_config.edn
+  [ "$status" -eq 1 ]
+}
+
 @test "Can parse nested files with name overlap (first)" {
   run ./conftest test -p examples/nested/policy --namespace group1 examples/nested/data.json
   [ "$status" -eq 1 ]

--- a/examples/edn/policy/deny.rego
+++ b/examples/edn/policy/deny.rego
@@ -1,0 +1,13 @@
+package main
+
+deny[msg] {
+  input[":env"] = ":development"
+  input[":log"] != ":debug"
+  msg = "Applications in the development environment should have debug logging"
+}
+
+deny[msg] {
+  input[":env"] = ":production"
+  input[":log"] != ":error"
+  msg = "Applications in the production environment should have error only logging"
+}

--- a/examples/edn/sample_config.edn
+++ b/examples/edn/sample_config.edn
@@ -1,0 +1,50 @@
+;; Sample configuration for myapp.
+
+{;; The db map is the set of values required to login to the postgres database
+ ;; we connect to.
+ :db {:user "my-username"
+      :pwd "secret"
+      :host "hostname.at.my-region.rds.amazonaws.com"
+      :db "databasename"
+      :port 5432}
+ ;; Configuration options for myapp
+ :myapp {;; Myapp is really available on 443 through reverse proxying done by
+         ;; nginx, to avoid handling SSL ourselves. 3000 is blocked to the
+         ;; public via iptables.
+         :port 3000
+         ;; The features are allowed on the form #{:foo :bar :baz}, but the
+         ;; common form :all is better when you want all enabled. All options
+         ;; available are: :admin-panel, :swear-filter, :ads,
+         ;; :keyboard-shortcuts and :pirate-lang. See the internal wiki page for
+         ;; details.
+         :features #{:admin-panel :keyboard-shortcuts} #_:all
+         ;; Configuration for the foo service which we depend on
+         :foo {;; The DNS entry to lookup to connect to a foo service. If you
+               ;; use the DNS to a specific cluster -- like "eu1.foo.mycorp.com"
+               ;; -- you only have to provide that key.
+               :hostname "foo.mycorp.com"
+               ;; Keys to the foo service. Starts with key1, goes on to key2 if
+               ;; that fails and so on. We'd like it to be a single key some
+               ;; day, but unfortunately we opened the foo API to some clients.
+               ;; As a stupid way to handle rate limiting we decided that it
+               ;; would be a good idea to use different keys for different
+               ;; clusters, instead of giving specific users specific keys
+               ;; instead.
+               :api-keys ["key1" "key2"]
+               ;; How often we check for more data from foo. It's recommended to
+               ;; turn this down to 20 minutes, because a lot of instances of
+               ;; bar would end up rechecking myapp waiting for data. Basically
+               ;; what caused the major outage earlier this year.
+               :recheck-frequency #duration "20m"}
+         ;; Timestamp to put on elements that will be cached forever by HTTP
+         ;; caches. If not set, it is placed one year ahead of the current time.
+         :forever-date #inst "2032-01-01T12:20:50.52Z"
+         ;; How many goroutines we should delegate to processing data.
+         :process-pool 5}
+ ;; The loglevel. Use :warn only if the logs become too verbose or you don't
+ ;; need the data, otherwise use :info. Use :debug only in development
+ ;; environments because that thing spits out basically everything.
+ :log :debug
+ ;; Which environment we're in. Has nothing to say for the app itself, but it's
+ ;; attached on the log messages sent to our centralised logging system.
+ :env :production}

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,5 @@ require (
 	github.com/spf13/viper v1.5.0
 	github.com/zclconf/go-cty v1.1.0
 	gopkg.in/ini.v1 v1.49.0 // indirect
+	olympos.io/encoding/edn v0.0.0-20191103180435-78e1aef28b15
 )

--- a/go.sum
+++ b/go.sum
@@ -392,3 +392,5 @@ gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
+olympos.io/encoding/edn v0.0.0-20191103180435-78e1aef28b15 h1:SLIxtGaiGmHPMYGhOecmIaVO4Zg2Ba66ioaVLR4s1Tg=
+olympos.io/encoding/edn v0.0.0-20191103180435-78e1aef28b15/go.mod h1:oVgVk4OWVDi43qWBEyGhXgYxt7+ED4iYNpTngSLX2Iw=

--- a/parser/edn/edn.go
+++ b/parser/edn/edn.go
@@ -1,0 +1,52 @@
+package edn
+
+import (
+	"fmt"
+
+	"olympos.io/encoding/edn"
+)
+
+type Parser struct{}
+
+// Unmarshal parses the EDN-encoded data and stores the result
+// in the value pointed to by v.
+func (tp *Parser) Unmarshal(p []byte, v interface{}) error {
+	var res interface{}
+
+	if err := edn.Unmarshal(p, &res); err != nil {
+		return fmt.Errorf("unmarshal EDN: %w", err)
+	}
+
+	*v.(*interface{}) = cleanupMapValue(res)
+
+	return nil
+}
+
+func cleanupInterfaceArray(in []interface{}) []interface{} {
+	res := make([]interface{}, len(in))
+	for i, v := range in {
+		res[i] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanupInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return cleanupInterfaceMap(v)
+	case string:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/parser/edn/edn_test.go
+++ b/parser/edn/edn_test.go
@@ -44,18 +44,16 @@ func TestEDNParser(t *testing.T) {
 				var unmarshalledConfigs interface{}
 				ednParser := new(edn.Parser)
 
-				err := ednParser.Unmarshal(test.controlConfigs, &unmarshalledConfigs)
-
-				if err != nil {
-					t.Errorf("we should not have any errors on unmarshalling: %v", err)
+				if err := ednParser.Unmarshal(test.controlConfigs, &unmarshalledConfigs); err != nil {
+					t.Errorf("err on unmarshalling: %v", err)
 				}
 
 				if unmarshalledConfigs == nil {
-					t.Error("we should see an actual value in our object, but we are nil")
+					t.Error("expected actual value in our object, got nil")
 				}
 
 				if !reflect.DeepEqual(test.expectedResult, unmarshalledConfigs) {
-					t.Errorf("Expected\n%T : %v\n to equal\n%T : %v\n", unmarshalledConfigs, unmarshalledConfigs, test.expectedResult, test.expectedResult)
+					t.Errorf("expected\n%T : %v\n to equal\n%T : %v\n", unmarshalledConfigs, unmarshalledConfigs, test.expectedResult, test.expectedResult)
 				}
 			})
 		}

--- a/parser/edn/edn_test.go
+++ b/parser/edn/edn_test.go
@@ -1,0 +1,63 @@
+package edn_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/instrumenta/conftest/parser/edn"
+)
+
+func TestEDNParser(t *testing.T) {
+	t.Run("we should be able to parse an EDN document", func(t *testing.T) {
+
+		testTable := []struct {
+			name           string
+			controlConfigs []byte
+			expectedResult interface{}
+			shouldError    bool
+		}{
+			{
+				name:           "a single config",
+				controlConfigs: []byte(`{:sample true}`),
+				expectedResult: map[string]interface{}{
+					":sample": "true",
+				},
+				shouldError: false,
+			},
+			{
+				name: "a basic edn file with a sample of types",
+				controlConfigs: []byte(`{;; This is a comment and should be ignored by the parser
+:sample1 "my-username",
+:sample2 false,
+:sample3 5432}`),
+				expectedResult: map[string]interface{}{
+					":sample1": "my-username",
+					":sample2": "false",
+					":sample3": "5432",
+				},
+				shouldError: false,
+			},
+		}
+
+		for _, test := range testTable {
+			t.Run(test.name, func(t *testing.T) {
+				var unmarshalledConfigs interface{}
+				ednParser := new(edn.Parser)
+
+				err := ednParser.Unmarshal(test.controlConfigs, &unmarshalledConfigs)
+
+				if err != nil {
+					t.Errorf("we should not have any errors on unmarshalling: %v", err)
+				}
+
+				if unmarshalledConfigs == nil {
+					t.Error("we should see an actual value in our object, but we are nil")
+				}
+
+				if !reflect.DeepEqual(test.expectedResult, unmarshalledConfigs) {
+					t.Errorf("Expected\n%T : %v\n to equal\n%T : %v\n", unmarshalledConfigs, unmarshalledConfigs, test.expectedResult, test.expectedResult)
+				}
+			})
+		}
+	})
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/instrumenta/conftest/parser/cue"
 	"github.com/instrumenta/conftest/parser/docker"
+	"github.com/instrumenta/conftest/parser/edn"
 	"github.com/instrumenta/conftest/parser/hcl2"
 	"github.com/instrumenta/conftest/parser/ini"
 	"github.com/instrumenta/conftest/parser/terraform"
@@ -23,6 +24,7 @@ func ValidInputs() []string {
 		"ini",
 		"yaml",
 		"json",
+		"edn",
 	}
 }
 
@@ -111,6 +113,8 @@ func GetParser(fileType string) (Parser, error) {
 		return &docker.Parser{}, nil
 	case "yml", "yaml", "json":
 		return &yaml.Parser{}, nil
+	case "edn":
+		return &edn.Parser{}, nil
 	default:
 		return nil, fmt.Errorf("unknown filetype given: %v", fileType)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/instrumenta/conftest/parser"
 	"github.com/instrumenta/conftest/parser/cue"
+	"github.com/instrumenta/conftest/parser/edn"
 	"github.com/instrumenta/conftest/parser/ini"
 	"github.com/instrumenta/conftest/parser/terraform"
 	"github.com/instrumenta/conftest/parser/toml"
@@ -228,6 +229,12 @@ func TestGetParser(t *testing.T) {
 			name:        "Test getting YAML parser from YAML input",
 			fileType:    "yaml",
 			expected:    new(yaml.Parser),
+			expectError: false,
+		},
+		{
+			name:        "Test getting EDN parser",
+			fileType:    "edn",
+			expected:    new(edn.Parser),
 			expectError: false,
 		},
 		{


### PR DESCRIPTION
Solves #2.

As requested by @garethr, this PR enables support for
[EDN](https://github.com/edn-format/edn) files as an input.

This PR touches on a number of things:

* It creates a new parser for edn files (parser/edn/...) and its tests
* Extends the parser interface to include the newly created edn parser
(and it tests it)
* Updades go mod and sum with the edn dependencies
* Creates examples policies and sample config files for EDN
* Updates acceptance tests to include the parsin of EDN files
* Updates the README