### PR TITLE
Consistent handling of errors and case in parsers

### DIFF
--- a/parser/cue/cue_test.go
+++ b/parser/cue/cue_test.go
@@ -23,8 +23,7 @@ func TestCueParser(t *testing.T) {
 
 	var input interface{}
 	parser := &Parser{}
-	err := parser.Unmarshal([]byte(p), &input)
-	if err != nil {
+	if err := parser.Unmarshal([]byte(p), &input); err != nil {
 		t.Fatalf("parser should not have thrown an error: %v", err)
 	}
 

--- a/parser/docker/docker_test.go
+++ b/parser/docker/docker_test.go
@@ -13,13 +13,12 @@ COPY . /
 RUN echo hello`
 
 	var input interface{}
-	err := parser.Unmarshal([]byte(sample), &input)
-	if err != nil {
+	if err := parser.Unmarshal([]byte(sample), &input); err != nil {
 		t.Fatalf("parser should not have thrown an error: %v", err)
 	}
 
 	if input == nil {
-		t.Error("There should be information parsed but its nil")
+		t.Error("there should be information parsed but its nil")
 	}
 
 	dockerFile := input.([]interface{})[0]
@@ -29,6 +28,6 @@ RUN echo hello`
 	actual := commands.(map[string]interface{})["Cmd"]
 
 	if actual != expected {
-		t.Errorf("First Docker command should be '%v', was '%v'", expected, actual)
+		t.Errorf("first Docker command should be '%v', was '%v'", expected, actual)
 	}
 }

--- a/parser/edn/edn_test.go
+++ b/parser/edn/edn_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestEDNParser(t *testing.T) {
-	t.Run("we should be able to parse an EDN document", func(t *testing.T) {
+	t.Run("error parsing EDN document", func(t *testing.T) {
 
 		testTable := []struct {
 			name           string

--- a/parser/ini/ini_test.go
+++ b/parser/ini/ini_test.go
@@ -6,30 +6,29 @@ import (
 
 func TestIniParser(t *testing.T) {
 	parser := &Parser{}
-	sample := `[Local Varaibles] 
-	Name=name 
-	Title=title 
+	sample := `[Local Varaibles]
+	Name=name
+	Title=title
 	Visisbility=show/hide
-	
-	[Navigation Controls] 
-	OnNext=node path 
+
+	[Navigation Controls]
+	OnNext=node path
 	Help=help file
-	
+
 	# Test comment`
 
 	var input interface{}
-	err := parser.Unmarshal([]byte(sample), &input)
-	if err != nil {
+	if err := parser.Unmarshal([]byte(sample), &input); err != nil {
 		t.Fatalf("parser should not have thrown an error: %v", err)
 	}
 
 	if input == nil {
-		t.Error("There should be information parsed but its nil")
+		t.Error("there should be information parsed but its nil")
 	}
 
 	inputMap := input.(map[string]interface{})
 	item := inputMap["Local Varaibles"]
 	if len(item.(map[string]interface{})) <= 0 {
-		t.Error("There should be at least one item defined in the parsed file, but none found")
+		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -19,7 +19,7 @@ import (
 // a map [k,v] where k is the filename and v is the document
 
 func TestUnmarshaller(t *testing.T) {
-	t.Run("we should be able to construct a unmarshaller for a type of file", func(t *testing.T) {
+	t.Run("error constructing an unmarshaller for a type of file", func(t *testing.T) {
 		configManager, err := parser.NewConfigManager("yml")
 		if err != nil {
 			t.Fatalf("create config parser: %v", err)
@@ -166,11 +166,11 @@ nice: true`)),
 					var unmarshalledConfigs map[string]interface{}
 					unmarshalledConfigs, err := configManager.BulkUnmarshal(test.controlReaders)
 					if err != nil {
-						t.Errorf("we should not have any errors on unmarshalling: %v", err)
+						t.Errorf("errors unmarshalling: %v", err)
 					}
 
 					if unmarshalledConfigs == nil {
-						t.Error("we should see an actual value in our object, but we are nil")
+						t.Error("error seeing the actual value of object, received nil")
 					}
 
 					if !reflect.DeepEqual(test.expectedResult, unmarshalledConfigs) {
@@ -253,10 +253,10 @@ func TestGetParser(t *testing.T) {
 				t.Errorf("expected: %T \n got this: %T", testUnit.expected, received)
 			}
 			if !testUnit.expectError && err != nil {
-				t.Errorf("we did not expect to see an error here: %v", err)
+				t.Errorf("error here: %v", err)
 			}
 			if testUnit.expectError && err == nil {
-				t.Error("we did not see an error even though one was expected")
+				t.Error("error expected but not received")
 			}
 		})
 	}

--- a/parser/terraform/terraform_test.go
+++ b/parser/terraform/terraform_test.go
@@ -14,17 +14,16 @@ func TestTerraformParser(t *testing.T) {
 		t.Fatalf("error reading sample file: %v", err)
 	}
 
-	err = parser.Unmarshal(sampleFileBytes, &input)
-	if err != nil {
+	if err = parser.Unmarshal(sampleFileBytes, &input); err != nil {
 		t.Fatalf("parser should not have thrown an error: %v", err)
 	}
 
 	if input == nil {
-		t.Error("There should be information parsed but its nil")
+		t.Error("there should be information parsed but its nil")
 	}
 
 	inputMap := input.(map[string]interface{})
 	if len(inputMap["resource"].([]map[string]interface{})) <= 0 {
-		t.Error("There should be resources defined in the parsed file, but none found")
+		t.Error("there should be resources defined in the parsed file, but none found")
 	}
 }

--- a/parser/yaml/yaml_test.go
+++ b/parser/yaml/yaml_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestYAMLParser(t *testing.T) {
-	t.Run("we should be able to parse a YAML document", func(t *testing.T) {
+	t.Run("error parsing a YAML document", func(t *testing.T) {
 
 		testTable := []struct {
 			name           string
@@ -52,14 +52,12 @@ nice: true`),
 				var unmarshalledConfigs interface{}
 				yamlParser := new(yaml.Parser)
 
-				err := yamlParser.Unmarshal(test.controlConfigs, &unmarshalledConfigs)
-
-				if err != nil {
-					t.Errorf("we should not have any errors on unmarshalling: %v", err)
+				if err := yamlParser.Unmarshal(test.controlConfigs, &unmarshalledConfigs); err != nil {
+					t.Errorf("errors unmarshalling: %v", err)
 				}
 
 				if unmarshalledConfigs == nil {
-					t.Error("we should see an actual value in our object, but we are nil")
+					t.Error("error seeing actual value in object, received nil")
 				}
 
 				if !reflect.DeepEqual(test.expectedResult, unmarshalledConfigs) {


### PR DESCRIPTION
It solves #171.

Firstly, I have looked for all two line handling errs (where there was a single return) and combined that as per the issue spec.

Secondly, I have also looked for all fmt strings where they started with a capital letter and changed that.

Lastly, I search for occurrences of 'we' within return strings and "impersonalised" them.