### PR TITLE
Fixed issue with json and tap output formats without trace

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -53,6 +53,18 @@
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
 
+@test "Test command with json output and trace flag" {
+  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -o json --trace
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "data.kubernetes.is_service" ]]
+}
+
+@test "Test command with tap output and trace flag" {
+  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -o tap --trace
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "data.kubernetes.is_service" ]]
+}
+
 @test "Verify command has trace flag" {
     run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]
@@ -130,7 +142,7 @@
   run ./conftest test -p examples/terraform/policy/gke.rego examples/terraform/gke.tf -i ini
   [ "$status" -eq 1 ]
 }
-  
+
 @test "Can combine configs and reference by file" {
   run ./conftest test -p examples/terraform/policy/gke_combine.rego examples/terraform/gke.tf --combine
   [ "$status" -eq 0 ]

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -108,6 +108,7 @@ type jsonCheckResult struct {
 	Warnings  []string `json:"warnings"`
 	Failures  []string `json:"failures"`
 	Successes []string `json:"successes"`
+	Traces    []string `json:"traces"`
 }
 
 // jsonOutputManager reports `conftest` results to `stdout` as a json array..
@@ -149,6 +150,7 @@ func (j *jsonOutputManager) Put(fileName string, cr CheckResult) error {
 		Warnings:  errsToStrings(cr.Warnings),
 		Failures:  errsToStrings(cr.Failures),
 		Successes: errsToStrings(cr.Successes),
+		Traces:    errsToStrings(cr.Traces),
 	})
 
 	return nil
@@ -197,7 +199,7 @@ func (s *tapOutputManager) Put(fileName string, cr CheckResult) error {
 		indicator = fmt.Sprintf(" - %s - ", fileName)
 	}
 
-	issues := len(cr.Failures) + len(cr.Warnings) + len(cr.Successes)
+	issues := len(cr.Failures) + len(cr.Warnings) + len(cr.Successes) + len(cr.Traces)
 	if issues > 0 {
 		s.logger.Print(fmt.Sprintf("1..%d", issues))
 		for i, r := range cr.Failures {
@@ -215,6 +217,13 @@ func (s *tapOutputManager) Put(fileName string, cr CheckResult) error {
 			for i, r := range cr.Successes {
 				counter := i + 1 + len(cr.Failures) + len(cr.Warnings)
 				s.logger.Print("ok ", counter, indicator, r)
+			}
+		}
+		if len(cr.Traces) > 0 {
+			s.logger.Print("# Traces")
+			for i, r := range cr.Traces {
+				counter := i + 1
+				s.logger.Print("trace ", counter, indicator, r)
 			}
 		}
 	}

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -86,7 +86,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"filename": "examples/kubernetes/service.yaml",
 		"warnings": [],
 		"failures": [],
-		"successes": []
+		"successes": [],
+		"traces": []
 	}
 ]
 `,
@@ -109,7 +110,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"failures": [
 			"first failure"
 		],
-		"successes": []
+		"successes": [],
+		"traces": []
 	}
 ]
 `,
@@ -129,7 +131,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"failures": [
 			"first failure"
 		],
-		"successes": []
+		"successes": [],
+		"traces": []
 	}
 ]
 `,
@@ -149,7 +152,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"failures": [
 			"first failure"
 		],
-		"successes": []
+		"successes": [],
+		"traces": []
 	}
 ]
 `,


### PR DESCRIPTION
@boranx, @Blokje5 , as per my comment in #183, this PR solves the issue.

It includes traces in the output of the `test -o json` command, and the `test -o tap` command, as well as acceptance tests for both cases.