### PR TITLE
Embedding traces in each one of the results

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ github.com/cockroachdb/apd/v2 v2.0.1 h1:y1Rh3tEU89D+7Tgbw+lp52T6p/GJLpDmNvr10UWq
 github.com/cockroachdb/apd/v2 v2.0.1/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/containerd/containerd v1.3.0 h1:xjvXQWABwS2uiv3TWgQt5Uth60Gu86LTGZXMJkjc7rY=
 github.com/containerd/containerd v1.3.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -44,7 +44,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 
 			var failures int
 			for _, result := range results {
-				if err := outputManager.Put(result.FileName, result); err != nil {
+				if err := outputManager.Put(result); err != nil {
 					return fmt.Errorf("put result: %w", err)
 				}
 
@@ -93,14 +93,8 @@ func runVerification(ctx context.Context, path string, trace bool) ([]CheckResul
 		msg := fmt.Errorf("%s", result.Package+"."+result.Name)
 		fileName := filepath.Join(path, result.Location.File)
 
-		var failure []error
-		var success []error
-
-		if result.Fail {
-			failure = []error{msg}
-		} else {
-			success = []error{msg}
-		}
+		var failure []Result
+		var success []Result
 
 		buf := new(bytes.Buffer)
 		topdown.PrettyTrace(buf, result.Trace)
@@ -111,11 +105,22 @@ func runVerification(ctx context.Context, path string, trace bool) ([]CheckResul
 			}
 		}
 
+		if result.Fail {
+			failure = append(failure, Result{
+				Message: msg,
+				Traces:  traces,
+			})
+		} else {
+			success = append(success, Result{
+				Message: msg,
+				Traces:  traces,
+			})
+		}
+
 		result := CheckResult{
 			FileName:  fileName,
 			Successes: success,
 			Failures:  failure,
-			Traces:    traces,
 		}
 
 		results = append(results, result)


### PR DESCRIPTION
This PR solves #186.

To do so, I extended the type `checkResult` and every member of it (failures, warnings and successes) is not of the newly created type `result`:

```
// Result describes the result of a single rule evaluation.
type Result struct {
	Message error
	Traces  []error
}

// CheckResult describes the result of a conftest evaluation.
// warning and failure "errors" produced by rego should be considered separate
// from other classes of exceptions.
type CheckResult struct {
	FileName  string
	Warnings  []Result
	Failures  []Result
	Successes []Result
}
```

This way, if traces are enabled we can capture them individually for each rule, and flush them out accordingly so the feedback is clearer and debugging your rules simpler.

In order to make it as straightforward as possible, I have simplified the way the `outputManagers` print the results, creating a function for each so the code is easier to read (it got a bit messy with loops inside loops for each trace of each result...).

This PR also fixes an issue I found along the way in that the newly created table output didn't include the `traces`.