### PR TITLE
Add trace output table

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -65,6 +65,12 @@
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
 
+@test "Test command with table output and trace flag" {
+  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -o table --trace
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "data.kubernetes.is_service" ]]
+}
+
 @test "Verify command has trace flag" {
     run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -275,6 +275,11 @@ func (s *tableOutputManager) Put(filename string, cr CheckResult) error {
 		s.table.Append(d)
 	}
 
+	for _, r := range cr.Traces {
+		d := []string{"trace", filename, r.Error()}
+		s.table.Append(d)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## What

* Add trace for `table` output

## Why

* Following https://github.com/instrumenta/conftest/pull/185
* Only table output has no trace