### PR TITLE
Added missing acceptance test for command trace with table output

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -65,6 +65,12 @@
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
 
+@test "Test command with table output and trace flag" {
+  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -o table --trace
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "data.kubernetes.is_service" ]]
+}
+
 @test "Verify command has trace flag" {
     run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Working with conftest today I've realised that we were missing the acceptance test for `--trace` with `table` output. This PR addresses that.