### PR TITLE
Enhancement of user feedback when using the verify command

### DIFF
--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -53,7 +53,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmd.AddCommand(NewParseCommand(ctx))
 	cmd.AddCommand(NewPushCommand(ctx, logger))
 	cmd.AddCommand(NewPullCommand(ctx))
-	cmd.AddCommand(NewVerifyCommand(ctx))
+	cmd.AddCommand(NewVerifyCommand(ctx, logger))
 
 	return &cmd
 }


### PR DESCRIPTION
This PR enhances the user feedback when using the `verify` command as per #14 

To do so, I have used the logger that was used across conftest (although I'm not a fan of the output). Happy to keep it or to change it as per collaborators guidelines.
