### PR TITLE
Add multi input file type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ The `--input` flag can also be a good way to see how different input types would
 conftest parse examples/hcl2/terraform.tf -i hcl2
 ```
 
+#### Multi input type
+
+Conftest supports different types of input file type in a single call.
+This does not assume all file types are the same.
+
+```console
+$ conftest test examples/multitype/grafana.ini examples/multitype/kubernetes.yaml -p examples/multitype
+```
+
 ### --combine flag
 
 This flag introduces *BREAKING CHANGES* in how `conftest` provides input to rego policies. However, you may find it useful to as you can now compare multiple values from different configurations simultaneously.
@@ -166,14 +175,6 @@ As of today `conftest` supports the following output types:
 - JSON: `--output=json`
 - [TAP](https://testanything.org/): `--output=tap`
 - Table `--output=table`
-
-## Multi input type
-
-Conftest supports different types of input file type.
-
-```console
-$ conftest parse examples/ini/grafana.ini examples/kubernetes/deployment.yaml
-```
 
 #### Example Output
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ As of today `conftest` supports the following output types:
 - [TAP](https://testanything.org/): `--output=tap`
 - Table `--output=table`
 
+## Multi input type
+
+Conftest supports different types of input file type.
+
+```console
+$ conftest parse examples/ini/grafana.ini examples/kubernetes/deployment.yaml
+```
+
 #### Example Output
 
 ##### Plaintext
@@ -232,6 +240,7 @@ You can find examples using various other tools in the `examples` directory, inc
 * [GitLab](examples/ci)
 * [Kubernetes](examples/kubernetes)
 * [Kustomize](examples/kustomize)
+* [Multitype](examples/multitype)
 * [Serverless Framework](examples/serverless)
 * [Tekton](examples/tekton)
 * [Terraform](examples/terraform)

--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ conftest parse examples/hcl2/terraform.tf -i hcl2
 
 #### Multi input type
 
-Conftest supports different types of input file type in a single call.
-This does not assume all file types are the same.
+`conftest` supports multiple different input types in a single call.
 
 ```console
 $ conftest test examples/multitype/grafana.ini examples/multitype/kubernetes.yaml -p examples/multitype

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -52,6 +52,12 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Test command with multiple input type" {
+  run ./conftest test examples/traefik/traefik.toml examples/kubernetes/service.yaml -p examples/kubernetes/policy 
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Found service hello-kubernetes but services are not allowed" ]]
+}
+
 @test "Test command has trace flag" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --trace
   [ "$status" -eq 0 ]
@@ -117,6 +123,12 @@
   run ./conftest test -p examples/xml/policy examples/xml/pom.xml
   [ "$status" -eq 1 ]
   [[ "$output" =~ "--- maven-plugin must have the version: 3.6.1" ]]
+}
+
+@test "Can parse multi-type files" {
+  run ./conftest test -p examples/multitype/policy examples/multitype/deployment.yaml examples/multitype/grafana.ini
+  [ "$status" -eq  1 ]
+  [[ "$output" =~ "Port should be" ]]
 }
 
 @test "Can parse nested files with name overlap (first)" {

--- a/examples/multitype/deployment.yaml
+++ b/examples/multitype/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - image: grafana/grafana:6.4.3
+        name: grafana
+        ports:
+        - containerPort: 3001
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/examples/multitype/grafana.ini
+++ b/examples/multitype/grafana.ini
@@ -1,0 +1,117 @@
+# possible values : production, development
+app_mode = production
+
+# instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+instance_name = ${HOSTNAME}
+
+#################################### Server ##############################
+[server]
+# Protocol (http, https, socket)
+protocol = http
+
+# The ip address to bind to, empty will bind to all interfaces
+http_addr =
+
+# The http port to use
+http_port = 3000
+
+# The public facing domain name used to access grafana from a browser
+domain = localhost
+
+# Redirect to correct domain if host header does not match domain
+# Prevents DNS rebinding attacks
+enforce_domain = false
+
+# The full public facing url
+root_url = %(protocol)s://%(domain)s:%(http_port)s/
+
+# Serve Grafana from subpath specified in `root_url` setting. By default it is set to `false` for compatibility reasons.
+serve_from_sub_path = false
+
+# Log web requests
+router_logging = false
+
+# the path relative working path
+static_root_path = public
+
+# enable gzip
+enable_gzip = false
+
+#################################### Users ###############################
+[users]
+# disable user signup / registration
+allow_sign_up = false
+
+# Allow non admin users to create organizations
+allow_org_create = false
+
+# Set to true to automatically assign new users to the default organization (id 1)
+auto_assign_org = true
+
+# Set this value to automatically add new users to the provided organization (if auto_assign_org above is set to true)
+auto_assign_org_id = 1
+
+# Default role new users will be automatically assigned (if auto_assign_org above is set to true)
+auto_assign_org_role = Viewer
+
+# Require email validation before sign up completes
+verify_email_enabled = false
+
+# Background text for the user field on the login page
+login_hint = email or username
+password_hint = password
+
+# Default UI theme ("dark" or "light")
+default_theme = dark
+
+# Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+viewers_can_edit = false
+
+# Editors can administrate dashboard, folders and teams they create
+editors_can_admin = false
+
+#################################### Alerting ############################
+[alerting]
+# Disable alerting engine & UI features
+enabled = true
+# Makes it possible to turn off alert rule execution but alerting UI is visible
+execute_alerts = true
+
+# Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+error_or_timeout = alerting
+
+# Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+nodata_or_nullvalues = no_data
+
+# Alert notifications can include images, but rendering many images at the same time can overload the server
+# This limit will protect the server from render overloading and make sure notifications are sent out quickly
+concurrent_render_limit = 5
+
+# Default setting for alert calculation timeout. Default value is 30
+evaluation_timeout_seconds = 30
+
+# Default setting for alert notification timeout. Default value is 30
+notification_timeout_seconds = 30
+
+# Default setting for max attempts to sending alert notifications. Default value is 3
+max_attempts = 3
+
+[auth]
+# Login cookie name
+login_cookie_name = grafana_session
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
+login_maximum_inactive_lifetime_days = 7
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+login_maximum_lifetime_days = 30
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+token_rotation_interval_minutes = 10
+
+# Set to true to disable (hide) the login form, useful if you use OAuth
+disable_login_form = false
+
+#################################### Basic Auth ##########################
+[auth.basic]
+enabled = true

--- a/examples/multitype/policy/base.rego
+++ b/examples/multitype/policy/base.rego
@@ -1,0 +1,18 @@
+package main
+
+import data.kubernetes
+import data.grafana
+
+port := 3000
+
+deny[msg] {
+    kubernetes.is_deployment
+    not input.spec.template.spec.containers[0].ports[0].containerPort = 3000
+    msg = sprintf("Port should be %d", [port])
+}
+
+deny[msg] {
+    grafana.is_config
+    not input.server.http_port = "3000"
+    msg = sprintf("Port should be %d", [port])
+}

--- a/examples/multitype/policy/grafana.rego
+++ b/examples/multitype/policy/grafana.rego
@@ -1,0 +1,5 @@
+package grafana
+
+is_config {
+    input.server["protocol"] = http
+}

--- a/examples/multitype/policy/kubernetes.rego
+++ b/examples/multitype/policy/kubernetes.rego
@@ -1,0 +1,5 @@
+package kubernetes
+
+is_deployment {
+    input.kind = "Deployment"
+}

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -1,0 +1,67 @@
+package parser
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetConfigurations(t *testing.T) {
+	testTabel := []struct {
+		name     string
+		fileList []string
+	}{
+		{
+			"Test single type",
+			[]string{"../examples/kubernetes/service.yaml"},
+		},
+		{
+			"Test two input with same type",
+			[]string{"../examples/kubernetes/service.yaml", "../examples/kubernetes/deployment.yaml"},
+		},
+		{
+			"Test different types",
+			[]string{
+				"../examples/kubernetes/service.yaml",
+				"../examples/traefik/traefik.toml",
+				"../examples/terraform/gke.tf",
+				"../examples/edn/sample_config.edn",
+			},
+		},
+	}
+
+	for _, testUnit := range testTabel {
+		t.Run(testUnit.name, func(t *testing.T) {
+			ctx := context.Background()
+			_, err := GetConfigurations(ctx, "", testUnit.fileList)
+			if err != nil {
+				t.Fatalf("error while getting configurations: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetFileType(t *testing.T) {
+	testTable := []struct {
+		name             string
+		inputFileType    string
+		filename         string
+		expectedFileType string
+	}{
+		{"Test YAML file", "", "example/kubernetes/deployment.yaml", "yaml"},
+		{"Test not YAML file", "", "example/traefik/traefik.toml", "toml"},
+		{"Test default file type", "", "-", "yaml"},
+	}
+
+	for _, testUnit := range testTable {
+		t.Run(testUnit.name, func(t *testing.T) {
+			fileType, err := getFileType(testUnit.inputFileType, testUnit.filename)
+			if err != nil {
+				t.Fatalf("errors getting filetype: %v", err)
+			}
+
+			if fileType != testUnit.expectedFileType {
+				t.Fatalf("got wrong filetype got:%s want:%s", fileType, testUnit.expectedFileType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

This pr implements multiple input type. For example, 

```
$ conftest test config.yml traefik.toml gke.tf -p /path/to/my/common/policy.rego
```

## Why

* Address https://github.com/instrumenta/conftest/issues/158
* In organizations, there are rules that don't depend on the file type.
    * For better policy abstraction, I thought multiple input type will be great.
* Before now, if you pass multiple inputs, it will try to parse with the parser associated with the first filetype as reported in the issue.