### PR TITLE
 Add feedback on invalid policy path

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -20,6 +20,11 @@
   [ "$status" -eq 1 ]
 }
 
+@test "Fail when testing with no policies path" {
+  run ./conftest test -p internal/ examples/kubernetes/deployment.yaml
+  [ "$status" -eq 1 ]
+}
+
 @test "Pass when testing a blank namespace" {
   run ./conftest test --namespace notpresent -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   [ "$status" -eq 0 ]
@@ -69,6 +74,11 @@
     run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]
   [[ "$output" =~ "data.kubernetes.is_service" ]]
+}
+
+@test "Fail when verifing with no policies path" {
+  run ./conftest verify -p internal/
+  [ "$status" -eq 1 ]
 }
 
 @test "Has help flag" {

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -77,6 +77,10 @@ func runVerification(ctx context.Context, path string, trace bool) ([]CheckResul
 		return nil, fmt.Errorf("read rego test files: %s", err)
 	}
 
+	if len(regoFiles) < 1 {
+		return nil, fmt.Errorf("no policies found in %s", path)
+	}
+
 	compiler, err := policy.BuildCompiler(regoFiles)
 	if err != nil {
 		return nil, fmt.Errorf("build compiler: %w", err)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -95,8 +95,13 @@ func getPolicyFiles(path string) ([]string, error) {
 
 		return nil
 	})
+
 	if err != nil {
 		return nil, err
+	}
+
+	if len(filepaths) < 1 {
+		return nil, fmt.Errorf("no policies found in %s", path)
 	}
 
 	return filepaths, nil


### PR DESCRIPTION
## What

When you pass file path with no policies, it will return an error message and it will exit with status `1`.

```
$ confest verify -p /no/policy/path/
Error: running verification: no policies found in /no/policy/path/
Usage:
  conftest verify [flags]

Flags:
  -h, --help            help for verify
  -o, --output string   output format for conftest results - valid options are: [stdout json tap]
      --trace           enable more verbose trace output for rego queries

Global Flags:
      --no-color        disable color when printing
  -p, --policy string   path to the Rego policy files directory. For the test command, specifying a specific .rego file is allowed. (default "policy")

exit status 1
```

Same as `test` command.

## Why

* https://github.com/instrumenta/conftest/issues/141
* Without this feature, the output is empty. Therefore, it looks like the test(or verification) succeeded.
* Moreover, the status code is `0`. This means that it is hard to detect these problems in CI.

```
$ confest verify -p /invalid/path
(nothing)

$ echo $?
=> 0
```
