### PR TITLE
fix test: run exactly against trace option with table

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -68,7 +68,7 @@
 @test "Test command with table output and trace flag" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -o table --trace
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "data.kubernetes.is_service" ]]
+  [[ "$output" =~ "| trace   | examples/kubernetes/service.yaml | Enter data.main.deny = _       |" ]]
 }
 
 @test "Verify command has trace flag" {


### PR DESCRIPTION
Regarding the test: `Test command with table output and trace flag`
I expect both outputs for `table` and `trace` if both `trace` and `table` option is enabled.  