### PR TITLE
Fail fast when getting configurations fails

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -72,6 +72,11 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("no file specified")
 			}
 
+			configurations, err := parser.GetConfigurations(ctx, viper.GetString("input"), nonBlankFileList)
+			if err != nil {
+				return fmt.Errorf("get configurations: %w", err)
+			}
+
 			policyPath := viper.GetString("policy")
 			urls := viper.GetStringSlice("update")
 			for _, url := range urls {
@@ -93,11 +98,6 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 			compiler, err := policy.BuildCompiler(regoFiles)
 			if err != nil {
 				return fmt.Errorf("build compiler: %w", err)
-			}
-
-			configurations, err := parser.GetConfigurations(ctx, viper.GetString("input"), nonBlankFileList)
-			if err != nil {
-				return fmt.Errorf("get configurations: %w", err)
 			}
 
 			namespace := viper.GetString("namespace")


### PR DESCRIPTION
# What

* Nits: Fail fast when GetConfigurations fail.

## Why

* Refactoring...
* Failing fast is better.
* Readability(these two lines got closer)

```golang
if len(nonBlankFileList) < 1 {
	return fmt.Errorf("no file specified")
}
```

```golang
configurations, err := parser.GetConfigurations(ctx, viper.GetString("input"), nonBlankFileList)
if err != nil {
	return fmt.Errorf("get configurations: %w", err)
}
```