### PR TITLE
Add supported filetype check

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -137,6 +137,11 @@
   [[ "$output" =~ "Application environment is should be `staging_environment`" ]]
 }
 
+@test "Fail when unsupported input type file" {
+  run ./conftest test -p examples/hcl2/policy examples/hcl2/terraform.tf -i invalid
+  [ "$status" -eq 1 ]
+}
+
 @test "Can parse stdin with input flag" {
   run bash -c "cat examples/ini/grafana.ini | ./conftest test -p examples/ini/policy --input ini -"
   [ "$status" -eq 1 ]

--- a/examples/kubernetes/deny.rego
+++ b/examples/kubernetes/deny.rego
@@ -1,0 +1,17 @@
+package main
+
+
+version {
+  to_number(input.version)
+}
+
+
+deny[msg] {
+  endswith(input.services[_].image, ":latest")
+  msg = "No images tagged latest"
+}
+
+deny[msg] {
+  version < 3.5
+  msg = "Must be using at least version 3.5 of the Compose file format"
+}

--- a/parser/config.go
+++ b/parser/config.go
@@ -20,6 +20,7 @@ var (
 		"cue",
 		"ini",
 		"yaml",
+		"yml",
 		"json",
 		"edn",
 		"xml",

--- a/parser/config.go
+++ b/parser/config.go
@@ -11,6 +11,22 @@ import (
 	"strings"
 )
 
+var (
+	supporedFileTypes = []string{
+		"toml",
+		"tf",
+		"hcl",
+		"hcl2",
+		"cue",
+		"ini",
+		"yaml",
+		"json",
+		"edn",
+		"xml",
+		"Dockerfile",
+	}
+)
+
 // GetConfigurations parses and returns the configurations given in the file list
 func GetConfigurations(ctx context.Context, input string, fileList []string) (map[string]interface{}, error) {
 	var configFiles []ConfigDoc
@@ -71,6 +87,10 @@ func getConfig(fileName string) (io.ReadCloser, error) {
 
 func getFileType(inputFileType, fileName string) (string, error) {
 	if inputFileType != "" {
+		if !isSupported(inputFileType) {
+			return "", fmt.Errorf("unsupported file type")
+		}
+
 		return inputFileType, nil
 	}
 
@@ -87,8 +107,22 @@ func getFileType(inputFileType, fileName string) (string, error) {
 			fileType = ss[len(ss)-1]
 		}
 
+		if !isSupported(fileType) {
+			return "", fmt.Errorf("unsupported file type")
+		}
+
 		return fileType, nil
 	}
 
 	return "", fmt.Errorf("unsupported file type")
+}
+
+func isSupported(fileType string) bool {
+	for _, t := range supporedFileTypes {
+		if fileType == t {
+			return true
+		}
+	}
+
+	return false
 }

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -1,0 +1,42 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestGetFileType(t *testing.T) {
+	testTable := []struct {
+		name            string
+		inputFileType   string
+		filename        string
+		expectdFileType string
+		shouldError     bool
+	}{
+		{"Test YAML file", "", "example/kubernetes/deployment.yaml", "yaml", false},
+		{"Test not YAML file", "", "example/traefik/traefik.toml", "toml", false},
+		{"Test default file type", "", "-", "yaml", false},
+		{"Test unsupported file type", "", "example/filetype.invalid", "", true},
+		{"Test unsupperted input file type", "invalid", "example/traefik/traefik.toml", "", true},
+	}
+
+	for _, testUnit := range testTable {
+		t.Run(testUnit.name, func(t *testing.T) {
+			fileType, err := getFileType(testUnit.inputFileType, testUnit.filename)
+			if err != nil {
+				if testUnit.shouldError {
+					return
+				}
+
+				t.Fatalf("errors getting filetype: %v", err)
+			}
+
+			if testUnit.shouldError {
+				t.Fatalf("expected errors but returned no error")
+			}
+
+			if fileType != testUnit.expectdFileType {
+				t.Fatalf("got wrong filetype got:%s want:%s", fileType, testUnit.expectdFileType)
+			}
+		})
+	}
+}

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -6,11 +6,11 @@ import (
 
 func TestGetFileType(t *testing.T) {
 	testTable := []struct {
-		name            string
-		inputFileType   string
-		filename        string
-		expectdFileType string
-		shouldError     bool
+		name             string
+		inputFileType    string
+		filename         string
+		expectedFileType string
+		shouldError      bool
 	}{
 		{"Test YAML file", "", "example/kubernetes/deployment.yaml", "yaml", false},
 		{"Test not YAML file", "", "example/traefik/traefik.toml", "toml", false},
@@ -34,8 +34,8 @@ func TestGetFileType(t *testing.T) {
 				t.Fatalf("expected errors but returned no error")
 			}
 
-			if fileType != testUnit.expectdFileType {
-				t.Fatalf("got wrong filetype got:%s want:%s", fileType, testUnit.expectdFileType)
+			if fileType != testUnit.expectedFileType {
+				t.Fatalf("got wrong filetype got:%s want:%s", fileType, testUnit.expectedFileType)
 			}
 		})
 	}


### PR DESCRIPTION
## What

* Add support file check

## Why

Currently use can specify any input file type and the test looks like succeeded until the Unmarshal fails.



