### PR TITLE
Add empty policy file detection

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -90,6 +90,10 @@ func getPolicyFiles(path string) ([]string, error) {
 		}
 
 		if filepath.Ext(currentPath) == ".rego" && !strings.HasSuffix(info.Name(), "_test.rego") {
+			if info.Size() == 0 {
+				return fmt.Errorf("empty policy found in %s", currentPath)
+			}
+
 			filepaths = append(filepaths, currentPath)
 		}
 


### PR DESCRIPTION
## What

* Add empty policy file detection

## Why

* OPA compiler will crash(=panic)
* #204 