### PR TITLE
print each of diagnostics

### DIFF
--- a/parser/hcl2/hcl2.go
+++ b/parser/hcl2/hcl2.go
@@ -14,7 +14,13 @@ func (h *Parser) Unmarshal(p []byte, v interface{}) error {
 	file, diags := hclsyntax.ParseConfig(p, "", hcl.Pos{Byte: 0, Line: 1, Column: 1})
 
 	if diags.HasErrors() {
-		return fmt.Errorf("parse hcl2 config: %s", diags.Error())
+		var details []error
+		for _, each := range diags.Errs() {
+			each = fmt.Errorf("%s \n", each)
+			details = append(details, each)
+		}
+
+		return fmt.Errorf("parse hcl2 config: \n %s", details)
 	}
 
 	content, err := convertFile(file)


### PR DESCRIPTION
It gives us more verbose compile errors for `hcl2`
Test it with invalid `hcl2` configs:

```shell
./conftest parse examples/edn/sample_config.edn -i hcl2
Error: failed during parser process: calling the parser method: bulk unmarshal: parser unmarshal: parse hcl2 config:
 [:1,1-2: Invalid character; The ";" character is not valid. Use newlines to separate arguments and blocks, and commas to separate items in collection values.
 :27,43-44: Invalid character; Single quotes are not valid. Use double quotes (") to enclose strings.
 :44,75-76: Invalid character; Single quotes are not valid. Use double quotes (") to enclose strings.
 :1,1-2: Argument or block definition required; An argument or block definition is required here.
]

```