### PR TITLE
Add types for ini

### DIFF
--- a/examples/ini/policy/deny.rego
+++ b/examples/ini/policy/deny.rego
@@ -1,17 +1,17 @@
 package main
 
 deny[msg] {
-  not input.alerting.enabled = "true"
+  not input.alerting.enabled = true
   msg = "Alerting should turned on"
 }
 
 deny[msg] {
-  not input["auth.basic"].enabled = "true"
+  not input["auth.basic"].enabled = true
   msg = "Basic auth should be enabled"
 }
 
 deny[msg] {
-  not input.server.http_port = "3000"
+  not input.server.http_port = 3000
   msg = "Grafana port should be 3000"
 }
 
@@ -21,11 +21,11 @@ deny[msg] {
 }
 
 deny[msg] {
-  not input.users.allow_sign_up = "false"
+  not input.users.allow_sign_up = false
   msg = "Users cannot sign up themselves"
 }
 
 deny[msg] {
-  not input.users.verify_email_enabled = "true"
+  not input.users.verify_email_enabled = true
   msg = "Users should verify their e-mail address"
 }

--- a/parser/ini/ini.go
+++ b/parser/ini/ini.go
@@ -3,6 +3,7 @@ package ini
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/go-ini/ini"
 )
@@ -15,15 +16,16 @@ func (i *Parser) Unmarshal(p []byte, v interface{}) error {
 		return fmt.Errorf("read ini file: %w", err)
 	}
 
-	result := make(map[string]map[string]string)
+	result := make(map[string]map[string]interface{})
 	for _, s := range cfg.Sections() {
 		sectionName := s.Name()
 		if sectionName == "DEFAULT" {
 			continue
 		}
 
-		result[sectionName] = map[string]string{}
-		result[sectionName] = s.KeysHash()
+		result[sectionName] = map[string]interface{}{}
+		keysHash := s.KeysHash()
+		result[sectionName] = convertKeyTypes(keysHash)
 	}
 
 	j, err := json.Marshal(result)
@@ -36,4 +38,33 @@ func (i *Parser) Unmarshal(p []byte, v interface{}) error {
 	}
 
 	return nil
+}
+
+func convertKeyTypes(keysHash map[string]string) map[string]interface{} {
+	val := map[string]interface{}{}
+
+	for k, v := range keysHash {
+		switch {
+		case isNumberLiteral(v):
+			f, _ := strconv.ParseFloat(v, 64)
+			val[k] = f
+		case isBooleanLiteral(v):
+			b, _ := strconv.ParseBool(v)
+			val[k] = b
+		default:
+			val[k] = v
+		}
+	}
+
+	return val
+}
+
+func isNumberLiteral(f string) bool {
+	_, err := strconv.ParseFloat(f, 64)
+	return err == nil
+}
+
+func isBooleanLiteral(b string) bool {
+	_, err := strconv.ParseBool(b)
+	return err == nil
 }

--- a/parser/ini/ini_test.go
+++ b/parser/ini/ini_test.go
@@ -10,6 +10,8 @@ func TestIniParser(t *testing.T) {
 	Name=name
 	Title=title
 	Visisbility=show/hide
+	Delay=10
+
 
 	[Navigation Controls]
 	OnNext=node path
@@ -30,5 +32,28 @@ func TestIniParser(t *testing.T) {
 	item := inputMap["Local Varaibles"]
 	if len(item.(map[string]interface{})) <= 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
+	}
+}
+
+func TestConvertTypes(t *testing.T) {
+	testTable := []struct {
+		name           string
+		input          map[string]string
+		expectedOutput interface{}
+	}{
+		{"Test number literal", map[string]string{"test": "3.0"}, 3.0},
+		{"Test string literal", map[string]string{"test": "conftest"}, "conftest"},
+		{"Test boolean literal", map[string]string{"test": "true"}, true},
+	}
+
+	for _, testUnit := range testTable {
+		t.Run(testUnit.name, func(t *testing.T) {
+			val := convertKeyTypes(testUnit.input)
+			for _, v := range val {
+				if v != testUnit.expectedOutput {
+					t.Fatalf("convert type got wrong value %v want %v", v, testUnit.expectedOutput)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

* Added type for input literal

## Why

* To address #206 
* Like other parsers, INI should pass values in `boolean`, `number`(int, float), `string` too.