### PR TITLE
Fix/Improve behaviour of OCI registry detection in conftest pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,19 @@ If you have a compatible OCI registry you can also push new policy bundles like 
 
 ```console
 conftest push instrumenta.azurecr.io/test
+conftest push 127.0.0.1:5000/test
+conftest push <some-other-supported-registry>/test
 ```
+
+OCI bundles can be pulled as well:
+
+```console
+conftest pull instrumenta.azurecr.io/test
+conftest pull 127.0.0.1:5000/test
+conftest pull oci://<some-other-supported-registry>/test
+```
+
+The Azure registy and 127.0.0.1:5000 (The local [Docker Registry](https://github.com/docker/distribution)) are special cases where the URL does not need to be prefixed with the scheme `oci://`, in all other cases the scheme needs to be provided in the URL.
 
 If you want to download the latest policies and run the tests in one go, you can do so with:
 

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/instrumenta/conftest/parser/docker"
-	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/instrumenta/conftest/parser/yaml"
 	"github.com/instrumenta/conftest/policy"
+	"github.com/open-policy-agent/opa/storage/inmem"
 )
 
 func TestWarnQuery(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -8,8 +8,8 @@ import (
 	"github.com/instrumenta/conftest/parser/cue"
 	"github.com/instrumenta/conftest/parser/docker"
 	"github.com/instrumenta/conftest/parser/edn"
-	"github.com/instrumenta/conftest/parser/hocon"
 	"github.com/instrumenta/conftest/parser/hcl2"
+	"github.com/instrumenta/conftest/parser/hocon"
 	"github.com/instrumenta/conftest/parser/ini"
 	"github.com/instrumenta/conftest/parser/terraform"
 	"github.com/instrumenta/conftest/parser/toml"
@@ -112,7 +112,7 @@ func GetParser(fileType string) (Parser, error) {
 	case "ini":
 		return &ini.Parser{}, nil
 	case "hocon":
-		return &hocon.Parser{},nil
+		return &hocon.Parser{}, nil
 	case "hcl2":
 		return &hcl2.Parser{}, nil
 	case "Dockerfile", "dockerfile":

--- a/policy/detect_oci.go
+++ b/policy/detect_oci.go
@@ -14,7 +14,7 @@ func (d *OCIDetector) Detect(src, _ string) (string, bool, error) {
 		return "", false, nil
 	}
 
-	if strings.Contains(src, "azurecr.io/") {
+	if strings.Contains(src, "azurecr.io/") || strings.Contains(src, "127.0.0.1:5000") {
 		url, err := d.detectHTTP(src)
 		if err != nil {
 			return "", false, err
@@ -46,6 +46,10 @@ func getRepositoryFromURL(url string) string {
 }
 
 func repositoryContainsTag(repository string) bool {
-	split := strings.Split(repository, "/")
-	return strings.Contains(split[len(split)-1], ":")
+	path := strings.Split(repository, "/")
+	return pathContainsTag(path[len(path)-1])
+}
+
+func pathContainsTag(path string) bool {
+	return strings.Contains(path, ":")
 }

--- a/policy/detect_oci_test.go
+++ b/policy/detect_oci_test.go
@@ -18,6 +18,16 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"user.azurecr.io/policies",
 			"oci://user.azurecr.io/policies:latest",
 		},
+		{
+			"should detect 127.0.0.1:5000 as most likely being an OCI registry",
+			"127.0.0.1:5000/policies:tag",
+			"oci://127.0.0.1:5000/policies:tag",
+		},
+		{
+			"should detect 127.0.0.1:5000 as most likely being an OCI registry and tag it properly if no tag is supplied",
+			"127.0.0.1:5000/policies",
+			"oci://127.0.0.1:5000/policies:latest",
+		},
 	}
 	pwd := "/pwd"
 	d := &OCIDetector{}

--- a/policy/get_oci.go
+++ b/policy/get_oci.go
@@ -24,6 +24,11 @@ func (g *OCIGetter) ClientMode(u *url.URL) (getter.ClientMode, error) {
 
 func (g *OCIGetter) Get(path string, u *url.URL) error {
 	ctx := g.Context()
+
+	if !pathContainsTag(u.Path) {
+		u.Path = u.Path + ":latest"
+	}
+
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("make policy directory: %w", err)


### PR DESCRIPTION
- Ensure that 127.0.0.1:5000 is treated as an OCI registry by default to keep conftest backwards compatible.

127.0.0.1:5000 is most likely a local docker registry. We can use the detect mechanism of go-getter to ensure that url is picked up as an OCI registry as well. Localhost could be included, but that sadly does not work due to the call to url.Parse before the detectors. `localhost:` fits the scheme regex. 

- Tag supplied OCI registry urls with latest if no tag was supplied. This is a QoL change I thought was nice as well.

- Update README to make it a bit clearer what is and isn't treated as an OCI registry

Fixes #218