### PR TITLE
Improve documentation for conftest commands

### DIFF
--- a/internal/commands/parse.go
+++ b/internal/commands/parse.go
@@ -12,12 +12,25 @@ import (
 	"github.com/spf13/viper"
 )
 
+const parseDesc = `
+This command prints the internal representation of your input files.
+
+This can be useful in helping to write Rego policies. It is not always clear how 
+your input file will be represented in the Rego policies. The type of the input is inferred
+based on the file extension. If inference is not possible (e.g. due to the file coming from stdin)
+the '--input' flag can be used to explicitly set the input type, e.g.:
+
+	$ conftest parse --input toml <input-file(s)>
+
+See the documentation of the '--input' flag for the supported input types.
+`
 // NewParseCommand creates a parse command.
 // This command can be used for printing structured inputs from unstructured configuration inputs.
 func NewParseCommand(ctx context.Context) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "parse [file...]",
 		Short: "Print out structured data from your input files",
+		Long: parseDesc,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := viper.BindPFlag("input", cmd.Flags().Lookup("input"))
 			if err != nil {

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -10,13 +10,46 @@ import (
 	"github.com/spf13/viper"
 )
 
+const pullDesc = `
+This command downloads individual policies from a remote location.
+
+Several locations are supported by the pull command. Under the hood
+conftest leverages go-getter (https://github.com/hashicorp/go-getter).
+The  following protocols are supported for downloading policies:
+
+	- OCI Registries
+	- Local Files
+	- Git
+	- HTTP/HTTPS
+	- Mercurial
+	- Amazon S3
+	- Google Cloud GCP
+
+The location of the policies is specified by passing an URL, e.g.:
+
+	$ conftest pull http://<my-policy-url>
+
+Based on the protocol a different mechanism will be used to download the policy.
+The pull command will also try to infer the protocol based on the URL if the 
+URL does not contain a protocol. For example, the OCI mechanism will be used if
+an azure registry URL is passed, e.g.
+
+	$ conftest pull instrumenta.azurecr.io/my-registry
+
+
+The policy location defaults to the policy directory in the local folder.
+The location can be overridden with the '--policy' flag, e.g.:
+
+	$ conftest push --policy <my-directory> <oci-url>
+`
+
 // NewPullCommand creates a new pull command to allow users
 // to download individual policies
 func NewPullCommand(ctx context.Context) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "pull <repository>",
 		Short: "Download individual policies",
-		Long:  `Download individual policies from a registry`,
+		Long:  pullDesc,
 		Args:  cobra.MinimumNArgs(1),
 
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -17,6 +17,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const pushDesc = `
+This command uploads Open Policy Agent bundles to an OCI registry
+
+Storing policies in OCI registries is similar to how Docker containers are stored.
+With conftest, Rego policies are bundled and pushed to the OCI registry e.g.:
+
+	$ conftest push instrumenta.azurecr.io/my-registry
+
+Optionally, a tag can be specified, e.g.:
+
+	$ conftest push instrumenta.azurecr.io/my-registry:v1
+
+If no tag is passed, by default, conftest uses the 'latest' tag. The policies can be retrieved
+using the pull command, e.g.:
+
+	$ conftest pull instrumenta.azurecr.io/my-registry:v1
+
+Alternatively, the policies can be pulled as part of running the test command:
+
+	$ conftest test --update instrumenta.azurecr.io/my-registry:v1 <my-input-file>
+
+Conftest leverages the ORAS library under the hood. This allows arbitrary artifacts to 
+be stored in compatible OCI registries. Currently open policy agent bundles are supported by 
+the docker/distribution (https://github.com/docker/distribution) registry and by Azure.
+
+The policy location defaults to the policy directory in the local folder.
+The location can be overridden with the '--policy' flag, e.g.:
+
+	$ conftest push --policy <my-directory> <oci-url>
+`
+
 const (
 	openPolicyAgentConfigMediaType      = "application/vnd.cncf.openpolicyagent.config.v1+json"
 	openPolicyAgentPolicyLayerMediaType = "application/vnd.cncf.openpolicyagent.policy.layer.v1+rego"
@@ -29,7 +60,7 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "push <repository> [filepath]",
 		Short: "Upload OPA bundles to an OCI registry",
-		Long:  `Upload Open Policy Agent bundles to an OCI registry`,
+		Long:  pushDesc,
 		Args:  cobra.RangeArgs(1, 2),
 
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -16,12 +16,50 @@ import (
 	"github.com/spf13/viper"
 )
 
+const verifyDesc = `
+This command executes Rego unit tests.
+
+Any file with a '_test' postfix and '.rego' extension will be compiled and 
+any Rego tests inside of them will be executed. For more information on how 
+to write tests check out the Rego testing documentation: 
+https://www.openpolicyagent.org/docs/latest/policy-testing/.
+
+The policy location defaults to the policy directory in the local folder.
+The location can be overridden with the '--policy' flag, e.g.:
+
+	$ conftest verify --policy <my-directory>
+
+Some policies are dependant on external data. This data is loaded in seperatly 
+from policies. The location of any data directory or file can be specified with 
+the '--data' flag. If a directory is specified, it will be recursively searched for 
+any data files. Right now any '.json' or '.yaml' file will be loaded in 
+and made available in the Rego policies. Data will be made available in Rego based on 
+the file path where the data was found. For example, if data is stored 
+under 'policy/exceptions/my_data.yaml', and we execute the following command:
+
+	$ conftest verify --data policy
+
+The data is available under 'import data.exceptions'.
+
+As with the test command, verify supports the '--output' flag to specify the type, e.g.:
+
+	$ conftest verify --output json
+
+For a full list of available output types, see the of the '--output' flag.
+
+When debugging policies it can be useful to use a more verbose policy evaluation output. By using the '--trace' flag
+the output will include a detailed trace of how the policy was evaluated, e.g.
+
+	$ conftest verify --trace <input-file>
+`
+
 // NewVerifyCommand creates a new verify command which allows users
 // to validate their rego unit tests
 func NewVerifyCommand(ctx context.Context) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "verify",
 		Short: "Verify Rego unit tests",
+		Long: verifyDesc,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flagNames := []string{"output", "trace", "data"}
 			for _, name := range flagNames {


### PR DESCRIPTION
The aim is to provide some guidenance for users of the conftest command without having to fall back to the README.
Several of the most common flags have been documented, along with their behaviour.