### PR TITLE
Support numerics as query name for improving readability

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -73,8 +73,8 @@ the output will include a detailed trace of how the policy was evaluated, e.g.
 `
 
 var (
-	denyQ                 = regexp.MustCompile("^(deny|violation)(_[a-zA-Z]+)*$")
-	warnQ                 = regexp.MustCompile("^warn(_[a-zA-Z]+)*$")
+	denyQ                 = regexp.MustCompile("^(deny|violation)(_[a-zA-Z0-9]+)*$")
+	warnQ                 = regexp.MustCompile("^warn(_[a-zA-Z0-9]+)*$")
 	combineConfigFlagName = "combine"
 )
 

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -20,6 +20,7 @@ func TestWarnQuery(t *testing.T) {
 		{"warnXYZ", false},
 		{"warn_", false},
 		{"warn_x", true},
+		{"warn_1", true},
 		{"warn_x_y_z", true},
 	}
 
@@ -48,6 +49,8 @@ func TestFailQuery(t *testing.T) {
 		{"violation_", false},
 		{"deny_x", true},
 		{"violation_x", true},
+		{"deny_1", true},
+		{"violation_1", true},
 		{"deny_x_y_z", true},
 		{"violation_x_y_z", true},
 	}


### PR DESCRIPTION
Deny and query name supports only alphabet now.
In this PR, add numerics support as query name for improving readability.

For example, validating `spec.replicas` is at least 3 in `deployment.yaml` of kubernetes  

```
deny_less_than_3_replicas[msg] {
  input.spec.replicas < 3
  msg = "spec.replicas is at least 3"
}
```