### PR TITLE
jsonOutputManager supports multiple files

### DIFF
--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -126,7 +126,7 @@ type jsonCheckResult struct {
 type jsonOutputManager struct {
 	logger *log.Logger
 
-	data jsonCheckResult
+	data []jsonCheckResult
 }
 
 func NewDefaultJSONOutputManager() *jsonOutputManager {
@@ -156,7 +156,7 @@ func (j *jsonOutputManager) Put(cr CheckResult) error {
 		cr.FileName = ""
 	}
 
-	j.data = jsonCheckResult{
+	result := jsonCheckResult{
 		Filename:  cr.FileName,
 		Warnings:  []jsonResult{},
 		Failures:  []jsonResult{},
@@ -165,12 +165,12 @@ func (j *jsonOutputManager) Put(cr CheckResult) error {
 
 	for _, warning := range cr.Warnings {
 		if len(warning.Traces) > 0 {
-			j.data.Warnings = append(j.data.Warnings, jsonResult{
+			result.Warnings = append(result.Warnings, jsonResult{
 				Message: warning.Message.Error(),
 				Traces:  errsToStrings(warning.Traces),
 			})
 		} else {
-			j.data.Warnings = append(j.data.Warnings, jsonResult{
+			result.Warnings = append(result.Warnings, jsonResult{
 				Message: warning.Message.Error(),
 			})
 		}
@@ -178,12 +178,12 @@ func (j *jsonOutputManager) Put(cr CheckResult) error {
 
 	for _, failure := range cr.Failures {
 		if len(failure.Traces) > 0 {
-			j.data.Failures = append(j.data.Failures, jsonResult{
+			result.Failures = append(result.Failures, jsonResult{
 				Message: failure.Message.Error(),
 				Traces:  errsToStrings(failure.Traces),
 			})
 		} else {
-			j.data.Failures = append(j.data.Failures, jsonResult{
+			result.Failures = append(result.Failures, jsonResult{
 				Message: failure.Message.Error(),
 			})
 		}
@@ -191,16 +191,18 @@ func (j *jsonOutputManager) Put(cr CheckResult) error {
 
 	for _, successes := range cr.Successes {
 		if len(successes.Traces) > 0 {
-			j.data.Successes = append(j.data.Successes, jsonResult{
+			result.Successes = append(result.Successes, jsonResult{
 				Message: successes.Message.Error(),
 				Traces:  errsToStrings(successes.Traces),
 			})
 		} else {
-			j.data.Successes = append(j.data.Successes, jsonResult{
+			result.Successes = append(result.Successes, jsonResult{
 				Message: successes.Message.Error(),
 			})
 		}
 	}
+
+	j.data = append(j.data, result)
 
 	return nil
 }

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -91,12 +91,14 @@ func Test_jsonOutputManager_put(t *testing.T) {
 			args: args{
 				cr: CheckResult{FileName: "examples/kubernetes/service.yaml"},
 			},
-			exp: `{
-	"filename": "examples/kubernetes/service.yaml",
-	"warnings": [],
-	"failures": [],
-	"successes": []
-}
+			exp: `[
+	{
+		"filename": "examples/kubernetes/service.yaml",
+		"warnings": [],
+		"failures": [],
+		"successes": []
+	}
+]
 `,
 		},
 		{
@@ -114,20 +116,22 @@ func Test_jsonOutputManager_put(t *testing.T) {
 						}},
 				},
 			},
-			exp: `{
-	"filename": "examples/kubernetes/service.yaml",
-	"warnings": [
-		{
-			"message": "first warning"
-		}
-	],
-	"failures": [
-		{
-			"message": "first failure"
-		}
-	],
-	"successes": []
-}
+			exp: `[
+	{
+		"filename": "examples/kubernetes/service.yaml",
+		"warnings": [
+			{
+				"message": "first warning"
+			}
+		],
+		"failures": [
+			{
+				"message": "first failure"
+			}
+		],
+		"successes": []
+	}
+]
 `,
 		},
 		{
@@ -141,16 +145,18 @@ func Test_jsonOutputManager_put(t *testing.T) {
 						}},
 				},
 			},
-			exp: `{
-	"filename": "examples/kubernetes/service.yaml",
-	"warnings": [],
-	"failures": [
-		{
-			"message": "first failure"
-		}
-	],
-	"successes": []
-}
+			exp: `[
+	{
+		"filename": "examples/kubernetes/service.yaml",
+		"warnings": [],
+		"failures": [
+			{
+				"message": "first failure"
+			}
+		],
+		"successes": []
+	}
+]
 `,
 		},
 		{
@@ -163,16 +169,18 @@ func Test_jsonOutputManager_put(t *testing.T) {
 							Message: errors.New("first failure"),
 						}}},
 			},
-			exp: `{
-	"filename": "",
-	"warnings": [],
-	"failures": [
-		{
-			"message": "first failure"
-		}
-	],
-	"successes": []
-}
+			exp: `[
+	{
+		"filename": "",
+		"warnings": [],
+		"failures": [
+			{
+				"message": "first failure"
+			}
+		],
+		"successes": []
+	}
+]
 `,
 		},
 	}


### PR DESCRIPTION
## Background

`conftest test` command can input multiple files and output for them.
(executed in `examples/kubernetes`)
```bash
conftest test service.yaml deployment.yaml
PASS - deployment.yaml - data.main.warn
FAIL - deployment.yaml - Containers must not run as root in Deployment hello-kubernetes
FAIL - deployment.yaml - Deployment hello-kubernetes must provide app/release labels for pod selectors
FAIL - deployment.yaml - hello-kubernetes must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
PASS - service.yaml - data.main.deny
WARN - service.yaml - Found service hello-kubernetes but services are not allowed
```

However `jsonOutputManager` is not support multiple files.
```bash
conftest test service.yaml deployment.yaml -o json
{
	"filename": "deployment.yaml",
	"warnings": [],
	"failures": [
		{
			"message": "hello-kubernetes must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels "
		},
		{
			"message": "Containers must not run as root in Deployment hello-kubernetes"
		},
		{
			"message": "Deployment hello-kubernetes must provide app/release labels for pod selectors"
		}
	],
	"successes": [
		{
			"message": "data.main.warn"
		}
	]
}
```

It's includes only results of `deployment.yaml` and missing  `service.yaml`.

## What is in this PR?

This PR fixs `jsonOutputManager` result to be that includes results of multiple files.

```bash
conftest test service.yaml deployment.yaml -o json
[
	{
		"filename": "service.yaml",
		"warnings": [
			{
				"message": "Found service hello-kubernetes but services are not allowed"
			}
		],
		"failures": [],
		"successes": [
			{
				"message": "data.main.deny"
			}
		]
	},
	{
		"filename": "deployment.yaml",
		"warnings": [],
		"failures": [
			{
				"message": "Containers must not run as root in Deployment hello-kubernetes"
			},
			{
				"message": "Deployment hello-kubernetes must provide app/release labels for pod selectors"
			},
			{
				"message": "hello-kubernetes must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels "
			}
		],
		"successes": [
			{
				"message": "data.main.warn"
			}
		]
	}
]
```

## Caution and Discuss
Caution if this PR merge is that will changes output format of jsonOutputManager.
It's to be nested by Array.

__Before checkout__
```bash
{
	"filename": "service.yaml",
	"warnings": [],
	"failures": [],
	"successes": []
}
``` 

__After checkout__
```bash
[
	{
		"filename": "service.yaml",
		"warnings": [],
		"failures": [],
		"successes": []
	}
]
``` 

What do you think?
I think after is better because other OutputManager results are support multiple files.