### PR TITLE
Change the HCL2 parser to output more structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ For the available parsers, take a look at: [parsers](parser). For instance:
 
 ```console
 $ conftest test -p examples/hcl2/policy examples/hcl2/terraform.tf -i hcl2
-FAIL - examples/hcl2/terraform.tf - Application environment is should be `staging_environment`
+FAIL - examples/hcl2/terraform.tf - ALB `my-alb-listener` is using HTTP rather than HTTPS
+FAIL - examples/hcl2/terraform.tf - ASG `my-rule` defines a fully open ingress
+FAIL - examples/hcl2/terraform.tf - Azure disk `source` is not encrypte
 ```
 
 The `--input` flag can also be a good way to see how different input types would be parsed:

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -168,7 +168,7 @@
 @test "Can parse hcl2 files" {
   run ./conftest test -p examples/hcl2/policy examples/hcl2/terraform.tf -i hcl2
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "Application environment is should be `staging_environment`" ]]
+  [[ "$output" =~ "ALB \`my-alb-listener\` is using HTTP rather than HTTP" ]]
 }
 
 @test "Can parse stdin with input flag" {

--- a/examples/hcl2/policy/deny_test.rego
+++ b/examples/hcl2/policy/deny_test.rego
@@ -1,0 +1,25 @@
+package main
+
+empty(value) {
+	count(value) == 0
+}
+
+no_violations {
+	empty(deny)
+}
+
+test_blank_input {
+    no_violations with input as {}
+}
+
+test_correctly_encrypted_azure_disk {
+    no_violations with input as {"resource": { "azurerm_managed_disk": { "sample": { "encryption_settings": { "enabled": true }}}}}
+}
+
+test_unencrypted_azure_disk {
+    deny["Azure disk `sample` is not encrypted"] with input as {"resource": { "azurerm_managed_disk": { "sample": { "encryption_settings": { "enabled": false }}}}}
+}
+
+test_fails_with_http_alb {
+    deny["ALB `name` is using HTTP rather than HTTPS"] with input as {"resource": { "aws_alb_listener": { "name": { "protocol": "HTTP" }}}}
+}

--- a/examples/hcl2/terraform.tf
+++ b/examples/hcl2/terraform.tf
@@ -1,34 +1,19 @@
-data "consul_key_prefix" "environment" {
-  path = "apps/example/env"
+resource "aws_security_group_rule" "my-rule" {
+    type        = "ingress"
+    cidr_blocks = ["0.0.0.0/0"]
 }
 
-resource "aws_elastic_beanstalk_environment" "example" {
-  name        = "test_environment"
-  application = "testing"
-
-  setting {
-    namespace = "aws:autoscaling:asg"
-    name      = "MinSize"
-    value     = "1"
-  }
-
-  dynamic "setting" {
-    for_each = data.consul_key_prefix.environment.var
-    content {
-      namespace = "aws:elasticbeanstalk:application:environment"
-      name      = setting.key
-      value     = setting.value
-    }
-  }
+resource "aws_alb_listener" "my-alb-listener"{
+    port     = "80"
+    protocol = "HTTP"
 }
 
-output "environment" {
-  value = {
-    id           = aws_elastic_beanstalk_environment.example.id
-    vpc_settings = {
-      for s in aws_elastic_beanstalk_environment.example.all_settings :
-      s.name => s.value
-      if s.namespace == "aws:ec2:vpc"
+resource "aws_db_security_group" "my-group" {
+
+}
+
+resource "azurerm_managed_disk" "source" {
+    encryption_settings {
+        enabled = false
     }
-  }
 }

--- a/parser/hcl2/convert_test.go
+++ b/parser/hcl2/convert_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 // This file is mostly attributed to https://github.com/tmccombs/hcl2json
-// It tests for merging block and labels for the given resource.
 
 const input = `
 resource "aws_elastic_beanstalk_environment" "example" {
@@ -46,26 +45,32 @@ resource "aws_elastic_beanstalk_environment" "example" {
   }`
 
 const expectedJSON = `{
-	"resource.aws_elastic_beanstalk_environment.example": {
-		"application": "testing",
-		"dynamic.setting": {
-			"content": {
-				"cond": "${test3 \u003e 2 ? 1: 0}",
-				"heredoc": "This is a heredoc template.\nIt references ${local.other.3}\n",
-				"heredoc2": "\t\t\tAnother heredoc, that\n\t\t\tdoesn't remove indentation\n\t\t\t${local.other.3}\n\t\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",
-				"loop": "This has a for loop: %{for x in local.arr}x,%{endfor}",
-				"name": "${setting.key}",
-				"namespace": "aws:elasticbeanstalk:application:environment",
-				"simple": "${4 - 2}",
-				"value": "${setting.value}"
-			},
-			"for_each": "${data.consul_key_prefix.environment.var}"
-		},
-		"name": "test_environment",
-		"setting": {
-			"name": "MinSize",
-			"namespace": "aws:autoscaling:asg",
-			"value": "1"
+	"resource": {
+		"aws_elastic_beanstalk_environment": {
+			"example": {
+				"application": "testing",
+				"dynamic": {
+					"setting": {
+						"content": {
+							"cond": "${test3 \u003e 2 ? 1: 0}",
+							"heredoc": "This is a heredoc template.\nIt references ${local.other.3}\n",
+							"heredoc2": "\t\t\tAnother heredoc, that\n\t\t\tdoesn't remove indentation\n\t\t\t${local.other.3}\n\t\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",
+							"loop": "This has a for loop: %{for x in local.arr}x,%{endfor}",
+							"name": "${setting.key}",
+							"namespace": "aws:elasticbeanstalk:application:environment",
+							"simple": "${4 - 2}",
+							"value": "${setting.value}"
+						},
+						"for_each": "${data.consul_key_prefix.environment.var}"
+					}
+				},
+				"name": "test_environment",
+				"setting": {
+					"name": "MinSize",
+					"namespace": "aws:autoscaling:asg",
+					"value": "1"
+				}
+			}
 		}
 	}
 }`


### PR DESCRIPTION
In hindsight, concating the names of the resources made writing generic
tests much harder. This change makes for more verbose output, but easier
tests.

This is a breaking change, but at this stage (ie. pre 1.0) I think
maintaining this behaviour isn't worthwhile.

Fixes #235 