### PR TITLE
Fix/Use absolute path instead of only filename for plugin loading

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -176,7 +176,8 @@ func FindPlugins() ([]*Plugin, error) {
 
 	for _, file := range files {
 		if file.IsDir() {
-			plugin, err := LoadPlugin(file.Name())
+			path := filepath.Join(pluginsCacheDirPath, file.Name())
+			plugin, err := LoadPlugin(path)
 			if err != nil {
 				return nil, fmt.Errorf("load plugin from cache directory: %w", err)
 			}


### PR DESCRIPTION
I had tested only with Symlinked local files apparently. I was trying out the git download functionality `conftest plugin install git::https://github.com/instrumenta/conftest.git//examples/plugins/kubectl` and ran into the issue that the file could not be loaded.