### PR TITLE
Show short help message for test output

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -98,7 +98,8 @@ type CheckResult struct {
 func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "test <file> [file...]",
-		Short: testDesc,
+		Short: "Test your configuration files using Open Policy Agent",
+		Long:  testDesc,
 		Args:  cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flagNames := []string{"fail-on-warn", "update", combineConfigFlagName, "trace", "output", "input", "namespace", "data"}


### PR DESCRIPTION
Reserve the long output for when folks explicitly request help on the
test subcommand. Otherwise this main running conftest without input very
verbose.

Fixes #237 