### PR TITLE
Fix plugin test on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 conftest
+conftest.exe
 dist
 
 # IDEs

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -8,30 +8,29 @@ import (
 )
 
 const (
-	ConftestDir     = ".conftest"
-	PluginsCacheDir = "plugins"
+	conftestDir     = ".conftest"
+	pluginsCacheDir = "plugins"
 )
 
 func fetchHomeDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("Could not fetch home directory: %w", err)
+		return "", fmt.Errorf("fetch home directory: %w", err)
 	}
 
 	return home, nil
 }
 
 func createPluginCacheDir(basePath string) (string, error) {
-	pluginsCacheDirPath := filepath.Join(basePath, ConftestDir, PluginsCacheDir)
+	pluginsCacheDirPath := filepath.Join(basePath, conftestDir, pluginsCacheDir)
 
 	if _, err := os.Stat(pluginsCacheDirPath); os.IsExist(err) {
-		// No need to create the directory if it exists
 		return pluginsCacheDirPath, nil
 	}
 
 	err := os.MkdirAll(pluginsCacheDirPath, 0700)
 	if err != nil {
-		return "", fmt.Errorf("Could not create conftest plugin cache: %w", err)
+		return "", fmt.Errorf("create conftest plugin cache: %w", err)
 	}
 
 	return pluginsCacheDirPath, nil

--- a/plugin/download.go
+++ b/plugin/download.go
@@ -12,7 +12,7 @@ import (
 func Download(ctx context.Context, url string) error {
 	homePath, err := fetchHomeDir()
 	if err != nil {
-		return fmt.Errorf("Fetch home path: %w", err)
+		return fmt.Errorf("fetch home path: %w", err)
 	}
 
 	cacheDirPath, err := createPluginCacheDir(homePath)
@@ -22,7 +22,7 @@ func Download(ctx context.Context, url string) error {
 
 	pwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("detect plugin, could not fetch pwd: %w", err)
+		return fmt.Errorf("get working dir: %w", err)
 	}
 
 	sourcedURL, err := downloader.Detect(url, pwd)
@@ -32,7 +32,6 @@ func Download(ctx context.Context, url string) error {
 
 	pluginDirPath := getPluginDirPath(cacheDirPath, sourcedURL)
 	if checkIfURLInCache(pluginDirPath) {
-		// Plugin already loaded, return directly
 		return nil
 	}
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -163,7 +163,7 @@ func FindPlugins() ([]*Plugin, error) {
 		return nil, fmt.Errorf("fetch home path: %w", err)
 	}
 
-	pluginsCacheDirPath := filepath.Join(homePath, ConftestDir, PluginsCacheDir)
+	pluginsCacheDirPath := filepath.Join(homePath, conftestDir, pluginsCacheDir)
 	if _, err := os.Stat(pluginsCacheDirPath); os.IsNotExist(err) {
 		// No plugins, so just return the empty slice
 		return plugins, nil

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -12,7 +12,7 @@ func TestLoadPlugin(t *testing.T) {
 	path := "testdata/test_plugin/"
 	plugin, err := LoadPlugin(path)
 	if err != nil {
-		t.Fatalf("Unexepected error loading plugin: %v", err)
+		t.Fatalf("Unexpected error loading plugin: %v", err)
 	}
 
 	expected := &MetaData{
@@ -88,13 +88,13 @@ func TestPlugin_Exec(t *testing.T) {
 			"Can execute a simple command",
 			&Plugin{
 				MetaData: &MetaData{
-					Command: Command("echo \"hello\""),
+					Command: Command("echo hello"),
 				},
 			},
 			[]string{},
 			[]string{},
 			[]string{
-				"\"hello\"",
+				"hello",
 			},
 			"",
 		},
@@ -117,7 +117,6 @@ func TestPlugin_Exec(t *testing.T) {
 				return
 			}
 
-			// Remove newlines out of stdout
 			processedStdOut := strings.Split(stdOut.String(), "\n")
 			if len(processedStdOut) > 0 {
 				processedStdOut = processedStdOut[:len(processedStdOut)-1]


### PR DESCRIPTION
`TestPlugin_Exec` was failing on Windows due to character escape shenanigans. 

This just simplifies the `echo` command to be `echo hello`