### PR TITLE
fix: Ensure that the correct plugin is loaded

### DIFF
--- a/internal/commands/load_plugins.go
+++ b/internal/commands/load_plugins.go
@@ -16,6 +16,7 @@ func loadPlugins(ctx context.Context) ([]*cobra.Command, error) {
 
 	var cmds []*cobra.Command
 	for _, plugin := range plugins {
+		plugin := plugin
 		metaData := plugin.MetaData
 		cmd := &cobra.Command{
 			Use:   metaData.Name,


### PR DESCRIPTION
The plugin variable was always the latest loaded plugin when having multiple plugins installed. 

See: https://github.com/golang/go/wiki/CommonMistakes for more details