### PR TITLE
parse hcl2 correctly

### DIFF
--- a/examples/hcl2/policy/deny.rego
+++ b/examples/hcl2/policy/deny.rego
@@ -13,7 +13,7 @@ deny[msg] {
 deny[msg] {
     rule := input.resource.aws_security_group_rule[name]
     rule.type == "ingress"
-    contains(rule.cidr_blocks, "0.0.0.0/0") 
+    contains(rule.cidr_blocks[_], "0.0.0.0/0") 
     msg = sprintf("ASG `%v` defines a fully open ingress", [name])
 }
 


### PR DESCRIPTION
Fix #249 

the output for the given input will be like that (which is what it should be)

```JSON
{
        "module": {
                "project_factory": {
                        "labels": {
                                "env": "dev"
                        },
                        "name": "${var.project_name}",
                        "source": "terraform-google-modules/project-factory/google",
                        "version": "~\u003e 6.0"
                }
        },
        "variable": {
                "project_name": {
                        "type": "${string}"
                }
        }
}
```
