### PR TITLE
Consolidate PASS output and notify when no policies found

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -203,13 +203,13 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 5 ]
+  [ "$count" -eq 8 ]
 }
 
 @test "Can verify rego tests" {
   run ./conftest verify --policy ./examples/kubernetes/policy
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "test_services_not_denied" ]]
+  [[ "$output" =~ "PASS: 4/4" ]]
 }
 
 @test "Can parse inputs with 'conftest parse'" {

--- a/examples/kubernetes/policy/labels.rego
+++ b/examples/kubernetes/policy/labels.rego
@@ -16,5 +16,5 @@ labels {
 deny[msg] {
   kubernetes.is_deployment
   not labels
-  msg = sprintf("%s must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels ", [name])
+  msg = sprintf("%s must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels", [name])
 }

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -84,7 +84,7 @@ func (s *stdOutputManager) Put(cr CheckResult) error {
 	}
 
 	printResults := func(r Result, prefix string, color aurora.Color) {
-		s.logger.Print(s.color.Colorize(prefix, color), indicator, r.Info["msg"])
+		s.logger.Print(s.color.Colorize(prefix, color), indicator, r.Message)
 		for _, t := range r.Traces {
 			s.logger.Print(s.color.Colorize("TRAC", aurora.BlueFg), indicator, t)
 		}
@@ -111,8 +111,9 @@ func (s *stdOutputManager) Flush() error {
 }
 
 type jsonResult struct {
-	Info   map[string]interface{} `json:"info"`
-	Traces []string               `json:"traces,omitempty"`
+	Message  string                 `json:"msg"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Traces   []string               `json:"traces,omitempty"`
 }
 
 type jsonCheckResult struct {
@@ -125,8 +126,7 @@ type jsonCheckResult struct {
 // jsonOutputManager reports `conftest` results to `stdout` as a json array..
 type jsonOutputManager struct {
 	logger *log.Logger
-
-	data []jsonCheckResult
+	data   []jsonCheckResult
 }
 
 func NewDefaultJSONOutputManager() *jsonOutputManager {
@@ -165,12 +165,14 @@ func (j *jsonOutputManager) Put(cr CheckResult) error {
 	for _, warning := range cr.Warnings {
 		if len(warning.Traces) > 0 {
 			result.Warnings = append(result.Warnings, jsonResult{
-				Info:   warning.Info,
-				Traces: errsToStrings(warning.Traces),
+				Message:  warning.Message,
+				Metadata: warning.Metadata,
+				Traces:   errsToStrings(warning.Traces),
 			})
 		} else {
 			result.Warnings = append(result.Warnings, jsonResult{
-				Info: warning.Info,
+				Message:  warning.Message,
+				Metadata: warning.Metadata,
 			})
 		}
 	}
@@ -178,12 +180,14 @@ func (j *jsonOutputManager) Put(cr CheckResult) error {
 	for _, failure := range cr.Failures {
 		if len(failure.Traces) > 0 {
 			result.Failures = append(result.Failures, jsonResult{
-				Info:   failure.Info,
-				Traces: errsToStrings(failure.Traces),
+				Message:  failure.Message,
+				Metadata: failure.Metadata,
+				Traces:   errsToStrings(failure.Traces),
 			})
 		} else {
 			result.Failures = append(result.Failures, jsonResult{
-				Info: failure.Info,
+				Message:  failure.Message,
+				Metadata: failure.Metadata,
 			})
 		}
 	}
@@ -191,12 +195,14 @@ func (j *jsonOutputManager) Put(cr CheckResult) error {
 	for _, successes := range cr.Successes {
 		if len(successes.Traces) > 0 {
 			result.Successes = append(result.Successes, jsonResult{
-				Info:   successes.Info,
-				Traces: errsToStrings(successes.Traces),
+				Message:  successes.Message,
+				Metadata: successes.Metadata,
+				Traces:   errsToStrings(successes.Traces),
 			})
 		} else {
 			result.Successes = append(result.Successes, jsonResult{
-				Info: successes.Info,
+				Message:  successes.Message,
+				Metadata: successes.Metadata,
 			})
 		}
 	}
@@ -249,7 +255,7 @@ func (s *tapOutputManager) Put(cr CheckResult) error {
 	}
 
 	printResults := func(r Result, prefix string, counter int) {
-		s.logger.Print(prefix, counter, indicator, r.Info["msg"])
+		s.logger.Print(prefix, counter, indicator, r.Message)
 		if len(r.Traces) > 0 {
 			s.logger.Print("# Traces")
 			for j, t := range r.Traces {

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -360,11 +360,3 @@ func (s *tableOutputManager) Flush() error {
 	}
 	return nil
 }
-
-func getTotalPoliciesChecked(checkResult CheckResult) int {
-	successes := len(checkResult.Successes)
-	warnings := len(checkResult.Warnings)
-	failures := len(checkResult.Failures)
-
-	return successes + warnings + failures
-}

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -30,7 +30,14 @@ func Test_stdOutputManager_put(t *testing.T) {
 					Failures: []Result{NewResult("first failure", []error{})},
 				},
 			},
-			exp: []string{"WARN - foo.yaml - first warning", "FAIL - foo.yaml - first failure"},
+			exp: []string{
+				"WARN - foo.yaml - first warning",
+				"FAIL - foo.yaml - first failure",
+				"--------------------------------------------------------------------------------",
+				"PASS: 0/2",
+				"WARN: 1/2",
+				"FAIL: 1/2",
+			},
 		},
 		{
 			msg: "skips filenames for stdin",
@@ -41,7 +48,14 @@ func Test_stdOutputManager_put(t *testing.T) {
 					Failures: []Result{NewResult("first failure", []error{})},
 				},
 			},
-			exp: []string{"WARN - first warning", "FAIL - first failure"},
+			exp: []string{
+				"WARN - first warning",
+				"FAIL - first failure",
+				"--------------------------------------------------------------------------------",
+				"PASS: 0/2",
+				"WARN: 1/2",
+				"FAIL: 1/2",
+			},
 		},
 	}
 
@@ -52,6 +66,10 @@ func Test_stdOutputManager_put(t *testing.T) {
 
 			if err := s.Put(tt.args.cr); err != nil {
 				t.Fatalf("put output: %v", err)
+			}
+
+			if err := s.Flush(); err != nil {
+				t.Fatalf("flush output: %v", err)
 			}
 
 			actual := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -102,16 +102,12 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"filename": "examples/kubernetes/service.yaml",
 		"warnings": [
 			{
-				"info": {
-					"msg": "first warning"
-				}
+				"msg": "first warning"
 			}
 		],
 		"failures": [
 			{
-				"info": {
-					"msg": "first failure"
-				}
+				"msg": "first failure"
 			}
 		],
 		"successes": []
@@ -133,9 +129,7 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"warnings": [],
 		"failures": [
 			{
-				"info": {
-					"msg": "first failure"
-				}
+				"msg": "first failure"
 			}
 		],
 		"successes": []
@@ -157,9 +151,7 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"warnings": [],
 		"failures": [
 			{
-				"info": {
-					"msg": "first failure"
-				}
+				"msg": "first failure"
 			}
 		],
 		"successes": []

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -80,12 +80,13 @@ var (
 
 // Result describes the result of a single rule evaluation.
 type Result struct {
-	Info   map[string]interface{}
-	Traces []error
+	Message  string
+	Metadata map[string]interface{}
+	Traces   []error
 }
 
 func (r Result) Error() string {
-	return r.Info["msg"].(string)
+	return r.Message
 }
 
 // CheckResult describes the result of a conftest evaluation.
@@ -100,8 +101,9 @@ type CheckResult struct {
 
 func NewResult(message string, traces []error) Result {
 	result := Result{
-		Info:   map[string]interface{}{"msg": message},
-		Traces: traces,
+		Message:  message,
+		Metadata: make(map[string]interface{}),
+		Traces:   traces,
 	}
 
 	return result
@@ -384,8 +386,12 @@ func runQuery(ctx context.Context, query string, input interface{}, compiler *as
 						}
 
 						result := NewResult(val["msg"].(string), traces)
-						for k, v := range val {
-							result.Info[k] = v
+						if len(val) > 1 {
+							for k, v := range val {
+								if k != "msg" {
+									result.Metadata[k] = v
+								}
+							}
 						}
 						errs = append(errs, result)
 					}


### PR DESCRIPTION
This PR takes a shot at #246 and a bit of #141 in the sense that when no policies are found, you'll be notified in the console.

The primary change here is leveraging the `.Flush()` method on the Standard Output manager. This gives us the entire picture (all files, checks, etc) before outputting to the console.

I've attached some before/afters for your convenience:

(test command with single file)
![conftest-test-singlefile](https://user-images.githubusercontent.com/6980197/75209327-dcfdb680-574b-11ea-8816-f93066be977f.png)

(test command with multiple files)
![conftest-test-multiplefiles](https://user-images.githubusercontent.com/6980197/75209331-df601080-574b-11ea-8c2f-d8ec57c6eb58.png)

(verify command with no failing policies)
![conftest-verify-nofailure](https://user-images.githubusercontent.com/6980197/75209335-e1c26a80-574b-11ea-9c8b-d224a8baa69b.png)

(verify command with two failing policies)
![conftest-verify-somefailures](https://user-images.githubusercontent.com/6980197/75209336-e38c2e00-574b-11ea-9375-25bff0bbbb9c.png)

(no policies found)
![image](https://user-images.githubusercontent.com/6980197/75209595-a70d0200-574c-11ea-9f0f-97ab78550c26.png)

The PASS/FAIL look and feel was taken from how OPA displays their results. Thought the synergy made sense.

Feedback appreciated