### PR TITLE
Made output.go viper-agnostic

### DIFF
--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/logrusorgru/aurora"
 	table "github.com/olekukonko/tablewriter"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -30,10 +29,8 @@ func ValidOutputs() []string {
 	}
 }
 
-func GetOutputManager() OutputManager {
-	outFmt := viper.GetString("output")
-	color := !viper.GetBool("no-color")
-
+// GetOutputManager returns the OutputManager based on the user input
+func GetOutputManager(outFmt string, color bool) OutputManager {
 	switch outFmt {
 	case outputSTD:
 		return NewDefaultStdOutputManager(color)

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/spf13/viper"
 )
 
 func Test_stdOutputManager_put(t *testing.T) {
@@ -258,8 +256,7 @@ func TestSupportedOutputManagers(t *testing.T) {
 			outputManager: NewDefaultStdOutputManager(true),
 		},
 	} {
-		viper.Set("output", testunit.outputFormat)
-		outputManager := GetOutputManager()
+		outputManager := GetOutputManager(testunit.outputFormat, true)
 		if !reflect.DeepEqual(outputManager, testunit.outputManager) {
 			t.Errorf(
 				"We expected the output manager to be of type %v : %T and it was %T",

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -128,7 +128,10 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		},
 
 		RunE: func(cmd *cobra.Command, fileList []string) error {
-			out := GetOutputManager()
+			outFmt := viper.GetString("output")
+			color := !viper.GetBool("no-color")
+
+			out := GetOutputManager(outFmt, color)
 
 			// Remove any blank files from the array
 			var nonBlankFileList []string

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -70,7 +70,10 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			outputManager := GetOutputManager()
+			outFmt := viper.GetString("output")
+			color := !viper.GetBool("no-color")
+
+			outputManager := GetOutputManager(outFmt, color)
 			policyPath := viper.GetString("policy")
 			trace := viper.GetBool("trace")
 


### PR DESCRIPTION
**What**
Making the `output.go` and its tests "spf13/viper"-agnostic, and abstract dealing with user input in the command files.

**Why**
Consistency.
Working with conftest the other day, I realised that our `output.go` was not "spf13/viper"-agnostic, and was pulling some information from arguments that I believe should have handled by its caller (in this case, the command `test.go`).