### PR TITLE
Directory support

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -166,7 +166,7 @@
 }
 
 @test "Can parse hcl2 files" {
-  run ./conftest test -p examples/hcl2/policy examples/hcl2/terraform.tf -i hcl2
+  run ./conftest test -p examples/hcl2/policy examples/hcl2/terraform.tf
   [ "$status" -eq 1 ]
   [[ "$output" =~ "ALB \`my-alb-listener\` is using HTTP rather than HTTP" ]]
 }
@@ -184,7 +184,7 @@
 }
 
 @test "Can combine configs and reference by file" {
-  run ./conftest test -p examples/terraform/policy/gke_combine.rego examples/terraform/gke.tf --combine
+  run ./conftest test -p examples/terraform/policy/gke_combine.rego examples/terraform/gke.tf --combine -i hcl1
   [ "$status" -eq 0 ]
 }
 

--- a/examples/terraform/gke.tf
+++ b/examples/terraform/gke.tf
@@ -2,8 +2,6 @@ provider "google" {
   version = "2.5.0"
   project = "instrumenta"
   region = "europe-west2"
-
-
 }
 
 resource "google_container_cluster" "primary" {

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -189,48 +189,27 @@ func (j *JSONOutputManager) Put(cr CheckResult) error {
 	}
 
 	for _, warning := range cr.Warnings {
-		if len(warning.Traces) > 0 {
-			result.Warnings = append(result.Warnings, jsonResult{
-				Message:  warning.Message,
-				Metadata: warning.Metadata,
-				Traces:   errsToStrings(warning.Traces),
-			})
-		} else {
-			result.Warnings = append(result.Warnings, jsonResult{
-				Message:  warning.Message,
-				Metadata: warning.Metadata,
-			})
-		}
+		result.Warnings = append(result.Warnings, jsonResult{
+			Message:  warning.Message,
+			Metadata: warning.Metadata,
+			Traces:   errsToStrings(warning.Traces),
+		})
 	}
 
 	for _, failure := range cr.Failures {
-		if len(failure.Traces) > 0 {
-			result.Failures = append(result.Failures, jsonResult{
-				Message:  failure.Message,
-				Metadata: failure.Metadata,
-				Traces:   errsToStrings(failure.Traces),
-			})
-		} else {
-			result.Failures = append(result.Failures, jsonResult{
-				Message:  failure.Message,
-				Metadata: failure.Metadata,
-			})
-		}
+		result.Failures = append(result.Failures, jsonResult{
+			Message:  failure.Message,
+			Metadata: failure.Metadata,
+			Traces:   errsToStrings(failure.Traces),
+		})
 	}
 
 	for _, successes := range cr.Successes {
-		if len(successes.Traces) > 0 {
-			result.Successes = append(result.Successes, jsonResult{
-				Message:  successes.Message,
-				Metadata: successes.Metadata,
-				Traces:   errsToStrings(successes.Traces),
-			})
-		} else {
-			result.Successes = append(result.Successes, jsonResult{
-				Message:  successes.Message,
-				Metadata: successes.Metadata,
-			})
-		}
+		result.Successes = append(result.Successes, jsonResult{
+			Message:  successes.Message,
+			Metadata: successes.Metadata,
+			Traces:   errsToStrings(successes.Traces),
+		})
 	}
 
 	j.data = append(j.data, result)

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -79,7 +79,6 @@ func (s *StandardOutputManager) Put(cr CheckResult) error {
 
 // Flush writes the contents of the managers buffer to the console
 func (s *StandardOutputManager) Flush() error {
-	var totalPolicies int
 	var totalFailures int
 	var totalWarnings int
 	var totalSuccesses int
@@ -124,8 +123,9 @@ func (s *StandardOutputManager) Flush() error {
 		totalFailures += len(cr.Failures)
 		totalWarnings += len(cr.Warnings)
 		totalSuccesses += len(cr.Successes)
-		totalPolicies += totalFailures + totalWarnings + totalSuccesses
 	}
+
+	totalPolicies := totalFailures + totalWarnings + totalSuccesses
 
 	s.logger.Print("--------------------------------------------------------------------------------")
 	s.logger.Print("PASS: ", totalSuccesses, "/", totalPolicies)

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -121,10 +121,10 @@ func (s *StandardOutputManager) Flush() error {
 			printResults(r, "FAIL", aurora.RedFg)
 		}
 
-		totalPolicies += currentPolicies
 		totalFailures += len(cr.Failures)
 		totalWarnings += len(cr.Warnings)
 		totalSuccesses += len(cr.Successes)
+		totalPolicies += totalFailures + totalWarnings + totalSuccesses
 	}
 
 	s.logger.Print("--------------------------------------------------------------------------------")

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -421,6 +421,15 @@ func buildRego(trace bool, query string, input interface{}, compiler *ast.Compil
 func parseFileList(fileList []string, input string) ([]string, error) {
 	var files []string
 	for _, file := range fileList {
+		if file == "" {
+			continue
+		}
+
+		if file == "-" {
+			files = append(files, "-")
+			continue
+		}
+
 		fileInfo, err := os.Stat(file)
 		if err != nil {
 			return nil, fmt.Errorf("get file info: %w", err)
@@ -456,7 +465,13 @@ func getFilesFromDirectory(directory string, input string) ([]string, error) {
 			return nil
 		}
 
-		for _, input := range parser.ValidInputs() {
+		if input == "" {
+			for _, input := range parser.ValidInputs() {
+				if strings.HasSuffix(info.Name(), inputToFileExtension(input)) {
+					files = append(files, currentPath)
+				}
+			}
+		} else {
 			if strings.HasSuffix(info.Name(), inputToFileExtension(input)) {
 				files = append(files, currentPath)
 			}
@@ -472,7 +487,7 @@ func getFilesFromDirectory(directory string, input string) ([]string, error) {
 }
 
 func inputToFileExtension(input string) string {
-	if input == "hcl2" {
+	if input == "hcl" {
 		return "tf"
 	}
 

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -44,7 +44,7 @@ func TestGetFileType(t *testing.T) {
 	testTable := []struct {
 		name             string
 		inputFileType    string
-		filename         string
+		fileName         string
 		expectedFileType string
 	}{
 		{"Test YAML file", "", "example/kubernetes/deployment.yaml", "yaml"},
@@ -54,11 +54,7 @@ func TestGetFileType(t *testing.T) {
 
 	for _, testUnit := range testTable {
 		t.Run(testUnit.name, func(t *testing.T) {
-			fileType, err := getFileType(testUnit.inputFileType, testUnit.filename)
-			if err != nil {
-				t.Fatalf("errors getting filetype: %v", err)
-			}
-
+			fileType := getFileType(testUnit.fileName, testUnit.inputFileType)
 			if fileType != testUnit.expectedFileType {
 				t.Fatalf("got wrong filetype got:%s want:%s", fileType, testUnit.expectedFileType)
 			}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -24,7 +24,7 @@ func ValidInputs() []string {
 	return []string{
 		"toml",
 		"tf",
-		"hcl",
+		"hcl1",
 		"hcl2",
 		"cue",
 		"ini",

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -129,5 +129,5 @@ func getFileType(fileName string, input string) string {
 
 	fileExtension := filepath.Ext(fileName)
 
-	return fileExtension[1:len(fileExtension)]
+	return fileExtension[1:]
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -22,11 +22,14 @@ import (
 func ValidInputs() []string {
 	return []string{
 		"toml",
-		"tf|hcl",
+		"tf",
+		"hcl",
 		"hcl2",
 		"cue",
 		"ini",
-		"yml|yaml|json",
+		"yml",
+		"yaml",
+		"json",
 		"Dockerfile",
 		"edn",
 		"vcl",

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,4 +1,4 @@
-package parser_test
+package parser
 
 import (
 	"io/ioutil"
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/instrumenta/conftest/parser"
 	"github.com/instrumenta/conftest/parser/cue"
 	"github.com/instrumenta/conftest/parser/edn"
 	"github.com/instrumenta/conftest/parser/ini"
@@ -17,22 +16,17 @@ import (
 
 func TestUnmarshaller(t *testing.T) {
 	t.Run("error constructing an unmarshaller for a type of file", func(t *testing.T) {
-		configManager, err := parser.NewConfigManager("yml")
-		if err != nil {
-			t.Fatalf("create config parser: %v", err)
-		}
-
 		t.Run("which can be used to BulkUnmarshal file contents into an object", func(t *testing.T) {
 			testTable := []struct {
 				name           string
-				controlReaders []parser.ConfigDoc
+				controlReaders []ConfigDoc
 				expectedResult map[string]interface{}
 				shouldError    bool
 			}{
 				{
 					name: "a single reader",
-					controlReaders: []parser.ConfigDoc{
-						parser.ConfigDoc{
+					controlReaders: []ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("sample: true")),
 							Filepath:   "sample.yml",
 						},
@@ -46,16 +40,16 @@ func TestUnmarshaller(t *testing.T) {
 				},
 				{
 					name: "multiple readers",
-					controlReaders: []parser.ConfigDoc{
-						parser.ConfigDoc{
+					controlReaders: []ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("sample: true")),
 							Filepath:   "sample.yml",
 						},
-						parser.ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("hello: true")),
 							Filepath:   "hello.yml",
 						},
-						parser.ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("nice: true")),
 							Filepath:   "nice.yml",
 						},
@@ -75,8 +69,8 @@ func TestUnmarshaller(t *testing.T) {
 				},
 				{
 					name: "a single reader with multiple yaml subdocs",
-					controlReaders: []parser.ConfigDoc{
-						parser.ConfigDoc{
+					controlReaders: []ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader(`---
 sample: true
 ---
@@ -103,8 +97,8 @@ nice: true`)),
 				},
 				{
 					name: "multiple readers with multiple subdocs",
-					controlReaders: []parser.ConfigDoc{
-						parser.ConfigDoc{
+					controlReaders: []ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader(`---
 sample: true
 ---
@@ -113,7 +107,7 @@ hello: true
 nice: true`)),
 							Filepath: "sample.yml",
 						},
-						parser.ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader(`---
 sample: true
 ---
@@ -122,7 +116,7 @@ hello: true
 nice: true`)),
 							Filepath: "hello.yml",
 						},
-						parser.ConfigDoc{
+						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("nice: true")),
 							Filepath:   "nice.yml",
 						},
@@ -161,7 +155,7 @@ nice: true`)),
 			for _, test := range testTable {
 				t.Run(test.name, func(t *testing.T) {
 					var unmarshalledConfigs map[string]interface{}
-					unmarshalledConfigs, err := configManager.BulkUnmarshal(test.controlReaders)
+					unmarshalledConfigs, err := BulkUnmarshal(test.controlReaders, "")
 					if err != nil {
 						t.Errorf("errors unmarshalling: %v", err)
 					}
@@ -183,7 +177,7 @@ func TestGetParser(t *testing.T) {
 	testTable := []struct {
 		name        string
 		fileType    string
-		expected    parser.Parser
+		expected    Parser
 		expectError bool
 	}{
 		{
@@ -244,7 +238,7 @@ func TestGetParser(t *testing.T) {
 
 	for _, testUnit := range testTable {
 		t.Run(testUnit.name, func(t *testing.T) {
-			received, err := parser.GetParser(testUnit.fileType)
+			received, err := GetParser(testUnit.fileType)
 
 			if !reflect.DeepEqual(received, testUnit.expected) {
 				t.Errorf("expected: %T \n got this: %T", testUnit.expected, received)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/instrumenta/conftest/parser/cue"
 	"github.com/instrumenta/conftest/parser/edn"
+	"github.com/instrumenta/conftest/parser/hcl2"
 	"github.com/instrumenta/conftest/parser/ini"
 	"github.com/instrumenta/conftest/parser/terraform"
 	"github.com/instrumenta/conftest/parser/toml"
@@ -181,15 +182,15 @@ func TestGetParser(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name:        "Test getting Terraform parser from HCL input",
-			fileType:    "hcl",
+			name:        "Test getting Terraform parser from HCL1 input",
+			fileType:    "hcl1",
 			expected:    new(terraform.Parser),
 			expectError: false,
 		},
 		{
-			name:        "Test getting Terraform parser from .tf input",
+			name:        "Test getting HCL2 parser from .tf input",
 			fileType:    "tf",
-			expected:    new(terraform.Parser),
+			expected:    new(hcl2.Parser),
 			expectError: false,
 		},
 		{


### PR DESCRIPTION
Resolves https://github.com/instrumenta/conftest/issues/260

**NOTE: This does include a breaking change (for tf and hcl files)**

This pull request adds support for running `conftest` against directories.

The biggest pain point I had was with `HCL` vs `HCL2` with `.TF` files. There's no real good way, as far as I'm aware, to pragmatically figure out which HCL flavor is in use. It's possible for `HCL` syntax to parse successfully as `HCL2`, but have the policies fail because of slight differences.

That said, `HCL` is on its way out and being sunsetted.

In short, I made it so that if a `.tf` or `.hcl` file is found, use the `HCL2` parser by default, rather than the `HCL1` parser. You can still use the `HCL1` parser by including `-i hcl1`.

This was mostly due to the fact that I believe this sets us up better for the future. For example, if you want to use conftest against a directory containing both `.tf` files and a `Dockerfile`, you could now do:

`conftest test mydirectorywiththatstuff`

Conftest will now go into the dir, grab all files with a file extension that we support (from the ValidInputs() method), and run policies against them. Because `HCL2` is the default, the included `.tf` files will be parsed using HCL2.

If I instead did

`conftest test mydirectorywiththatstuff -i hcl1`

_ONLY_ `.tf` files would be validated, and they'd be validated using hcl1. The `Dockerfile` would not be grabbed for validation.

In other words, now when using `-i` and a directory as an input, `-i` dictates which files to grab.

In the future, `HCL1` validation should just go away entirely.

Thoughts?