### PR TITLE
Introduce --all-namespaces flag #236

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -82,6 +82,13 @@
   [[ "$output" =~ "| trace   | examples/kubernetes/service.yaml | Enter data.main.deny = _       |" ]]
 }
 
+@test "Test command with all namespaces flag" {
+  run ./conftest test -p examples/docker/policy examples/docker/Dockerfile --all-namespaces
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "blacklisted image found [\"openjdk:8-jdk-alpine\"]" ]]
+  [[ "$output" =~ "blacklisted commands found [\"apk add --no-cache python3 python3-dev build-base && pip3 install awscli==1.18.1\"]" ]]
+}
+
 @test "Verify command has trace flag" {
     run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -6,4 +6,6 @@ COPY ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY ${DEPENDENCY}/META-INF /app/META-INF
 COPY ${DEPENDENCY}/BOOT-INF/classes /app
 
+RUN apk add --no-cache python3 python3-dev build-base && pip3 install awscli==1.18.1
+
 ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]

--- a/examples/docker/policy/commands.rego
+++ b/examples/docker/policy/commands.rego
@@ -1,0 +1,17 @@
+package commands
+
+blacklist = [
+  "apk",
+  "apt",
+  "pip",
+  "curl",
+  "wget",
+]
+
+deny[msg] {
+  input[i].Cmd == "run"
+  val := input[i].Value
+  contains(val[_], blacklist[_])
+
+  msg = sprintf("blacklisted commands found %s", [val])
+}

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -94,7 +94,7 @@ metadata:
 	}
 
 	store := inmem.New()
-	const defaultNamespace = "main"
+	defaultNamespace := []string{"main"}
 	results, err := GetResult(ctx, defaultNamespace, jsonConfig, compiler, store)
 	if err != nil {
 		t.Fatalf("could not process policy file: %s", err)
@@ -141,7 +141,7 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 	}
 
 	store := inmem.New()
-	const defaultNamespace = "main"
+	defaultNamespace := []string{"main"}
 	results, err := GetResult(ctx, defaultNamespace, jsonConfig, compiler, store)
 	if err != nil {
 		t.Fatalf("could not process policy file: %s", err)

--- a/policy/namespace.go
+++ b/policy/namespace.go
@@ -1,0 +1,23 @@
+package policy
+
+import (
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// GetNamespaces returns a list of all namespaces in a set of given policies
+func GetNamespaces(regoFiles []string, compiler *ast.Compiler) ([]string, error) {
+	namespaces := []string{}
+	exists := map[string]bool{}
+	for _, regoFile := range regoFiles {
+		for _, path := range compiler.Modules[regoFile].Package.Path {
+			value := path.Value.String()
+			if value != "data" && !exists[value] {
+				namespaces = append(namespaces, strings.ReplaceAll(path.Value.String(), "\"", ""))
+				exists[value] = true
+			}
+		}
+	}
+	return namespaces, nil
+}


### PR DESCRIPTION
As per #236, this PR introduces a new flag to make conftest search all namespaces available in the policies and find "deny.*" and "warn.* rules within.

I have created a new test for it in the Docker examples.