### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ FAIL - deployment.yaml - Containers must not run as root
 FAIL - deployment.yaml - Deployments are not allowed
 ```
 
-Cconftest isn't specific to Kubernetes. It will happily let you write tests for any configuration files in a variety of different formats.
+Conftest isn't specific to Kubernetes. It will happily let you write tests for any configuration files in a variety of different formats.
 
 See the [documentation](https://www.conftest.dev/) for [installation instructions](https://www.conftest.dev/install/) and
 more details about the features. For discussions and questions join us on the [Open Policy Agent Slack](https://slack.openpolicyagent.org/)


### PR DESCRIPTION
Small typo I noticed after the `README` went live