### PR TITLE
Reduce input variable footprint

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -392,7 +392,7 @@ func (t TestRun) runQuery(ctx context.Context, query string, input interface{}) 
 	for _, result := range resultSet {
 		for _, expression := range result.Expressions {
 
-			if hasResults(expression.Value) == false {
+			if !hasResults(expression.Value) {
 				successes = append(successes, NewResult(expression.Text, traces))
 				continue
 			}

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -259,28 +259,29 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 
 // GetResult returns the result of testing the structured data against their policies
 func (t TestRun) GetResult(ctx context.Context, namespaces []string, input interface{}) (CheckResult, error) {
-	var totalSuccesses, warnings, successes, failures []Result
+	var successes []Result
+	var totalSuccesses []Result
 
+	var warnings []Result
 	for _, namespace := range namespaces {
 		tmpWarnings, tmpSuccesses, err := t.runRules(ctx, namespace, input, warnQ)
 		if err != nil {
-			return CheckResult{}, err
+			return CheckResult{}, fmt.Errorf("run rules: %w", err)
 		}
 		warnings = append(warnings, tmpWarnings...)
 		successes = append(successes, tmpSuccesses...)
 	}
-
 	totalSuccesses = append(totalSuccesses, successes...)
 
+	var failures []Result
 	for _, namespace := range namespaces {
 		tmpFailures, tmpSuccesses, err := t.runRules(ctx, namespace, input, denyQ)
 		if err != nil {
-			return CheckResult{}, err
+			return CheckResult{}, fmt.Errorf("run rules: %w", err)
 		}
 		failures = append(failures, tmpFailures...)
 		successes = append(successes, tmpSuccesses...)
 	}
-
 	totalSuccesses = append(totalSuccesses, successes...)
 
 	result := CheckResult{

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -93,9 +93,13 @@ metadata:
 		t.Fatalf("could not build rego compiler: %s", err)
 	}
 
-	store := inmem.New()
+	testRun := TestRun{
+		Compiler: compiler,
+		Store:    inmem.New(),
+	}
+
 	defaultNamespace := []string{"main"}
-	results, err := GetResult(ctx, defaultNamespace, jsonConfig, compiler, store)
+	results, err := testRun.GetResult(ctx, defaultNamespace, jsonConfig)
 	if err != nil {
 		t.Fatalf("could not process policy file: %s", err)
 	}
@@ -140,9 +144,13 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 		t.Fatalf("could not build rego compiler: %s", err)
 	}
 
-	store := inmem.New()
+	testRun := TestRun{
+		Compiler: compiler,
+		Store:    inmem.New(),
+	}
+
 	defaultNamespace := []string{"main"}
-	results, err := GetResult(ctx, defaultNamespace, jsonConfig, compiler, store)
+	results, err := testRun.GetResult(ctx, defaultNamespace, jsonConfig)
 	if err != nil {
 		t.Fatalf("could not process policy file: %s", err)
 	}

--- a/parser/config.go
+++ b/parser/config.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 )
 
-// ConfigDoc ...
+// ConfigDoc is an input document to be checked
 type ConfigDoc struct {
 	ReadCloser io.ReadCloser
 	Filepath   string

--- a/parser/config.go
+++ b/parser/config.go
@@ -10,6 +10,13 @@ import (
 	"path/filepath"
 )
 
+// ConfigDoc ...
+type ConfigDoc struct {
+	ReadCloser io.ReadCloser
+	Filepath   string
+	Parser     Parser
+}
+
 // GetConfigurations parses and returns the configurations given in the file list
 func GetConfigurations(ctx context.Context, input string, fileList []string) (map[string]interface{}, error) {
 	var fileConfigs []ConfigDoc
@@ -22,20 +29,47 @@ func GetConfigurations(ctx context.Context, input string, fileList []string) (ma
 			return nil, fmt.Errorf("get config: %w", err)
 		}
 
+		fileType := getFileType(fileName, input)
+		parser, err := GetParser(fileType)
+		if err != nil {
+			return nil, fmt.Errorf("get parser: %w", err)
+		}
+
 		configDoc := ConfigDoc{
 			ReadCloser: config,
 			Filepath:   fileName,
+			Parser:     parser,
 		}
 
 		fileConfigs = append(fileConfigs, configDoc)
 	}
 
-	unmarshaledConfigs, err := BulkUnmarshal(fileConfigs, input)
+	unmarshaledConfigs, err := bulkUnmarshal(fileConfigs)
 	if err != nil {
 		return nil, fmt.Errorf("bulk unmarshal: %w", err)
 	}
 
 	return unmarshaledConfigs, nil
+}
+
+func bulkUnmarshal(configList []ConfigDoc) (map[string]interface{}, error) {
+	configContents := make(map[string]interface{})
+	for _, config := range configList {
+		contents, err := ioutil.ReadAll(config.ReadCloser)
+		if err != nil {
+			return nil, fmt.Errorf("read config: %w", err)
+		}
+
+		var singleContent interface{}
+		if err := config.Parser.Unmarshal(contents, &singleContent); err != nil {
+			return nil, fmt.Errorf("parser unmarshal: %w", err)
+		}
+
+		configContents[config.Filepath] = singleContent
+		config.ReadCloser.Close()
+	}
+
+	return configContents, nil
 }
 
 func getConfig(fileName string) (io.ReadCloser, error) {
@@ -55,4 +89,22 @@ func getConfig(fileName string) (io.ReadCloser, error) {
 	}
 
 	return config, nil
+}
+
+func getFileType(fileName string, input string) string {
+	if input != "" {
+		return input
+	}
+
+	if fileName == "-" {
+		return "yaml"
+	}
+
+	if filepath.Ext(fileName) == "" {
+		return filepath.Base(fileName)
+	}
+
+	fileExtension := filepath.Ext(fileName)
+
+	return fileExtension[1:]
 }

--- a/parser/config.go
+++ b/parser/config.go
@@ -21,10 +21,9 @@ type ConfigDoc struct {
 func GetConfigurations(ctx context.Context, input string, fileList []string) (map[string]interface{}, error) {
 	var fileConfigs []ConfigDoc
 	for _, fileName := range fileList {
-		var err error
 		var config io.ReadCloser
 
-		config, err = getConfig(fileName)
+		config, err := getConfig(fileName)
 		if err != nil {
 			return nil, fmt.Errorf("get config: %w", err)
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -30,6 +30,7 @@ func TestUnmarshaller(t *testing.T) {
 						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("sample: true")),
 							Filepath:   "sample.yml",
+							Parser:     &yaml.Parser{},
 						},
 					},
 					expectedResult: map[string]interface{}{
@@ -45,14 +46,17 @@ func TestUnmarshaller(t *testing.T) {
 						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("sample: true")),
 							Filepath:   "sample.yml",
+							Parser:     &yaml.Parser{},
 						},
 						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("hello: true")),
 							Filepath:   "hello.yml",
+							Parser:     &yaml.Parser{},
 						},
 						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("nice: true")),
 							Filepath:   "nice.yml",
+							Parser:     &yaml.Parser{},
 						},
 					},
 					expectedResult: map[string]interface{}{
@@ -79,6 +83,7 @@ hello: true
 ---
 nice: true`)),
 							Filepath: "sample.yml",
+							Parser:   &yaml.Parser{},
 						},
 					},
 					expectedResult: map[string]interface{}{
@@ -107,6 +112,7 @@ hello: true
 ---
 nice: true`)),
 							Filepath: "sample.yml",
+							Parser:   &yaml.Parser{},
 						},
 						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader(`---
@@ -116,10 +122,12 @@ hello: true
 ---
 nice: true`)),
 							Filepath: "hello.yml",
+							Parser:   &yaml.Parser{},
 						},
 						ConfigDoc{
 							ReadCloser: ioutil.NopCloser(strings.NewReader("nice: true")),
 							Filepath:   "nice.yml",
+							Parser:     &yaml.Parser{},
 						},
 					},
 					expectedResult: map[string]interface{}{
@@ -156,7 +164,7 @@ nice: true`)),
 			for _, test := range testTable {
 				t.Run(test.name, func(t *testing.T) {
 					var unmarshalledConfigs map[string]interface{}
-					unmarshalledConfigs, err := BulkUnmarshal(test.controlReaders, "")
+					unmarshalledConfigs, err := bulkUnmarshal(test.controlReaders)
 					if err != nil {
 						t.Errorf("errors unmarshalling: %v", err)
 					}


### PR DESCRIPTION
This feels like a better layout, but feedback welcomed.

Working through some PRs relating to `-i` I noticed that `input` was driving a lot of behavior and causing a lot of branching. It is/was starting to bleed everywhere.

For example, input was a parameter in 3 different functions, but was not used in any of them except to make a call at the very end of the chain:

`GetConfigurations` -> `BulkUnmarshal` -> `getFileType` .. ultimately just to use it to call `GetParser`

So this lifts `input` much closer to the top, and associates the `Parser` with a `ConfigDoc`.

This PR also removes a lot of the `compiler` and `store` params that were repeated quite often into a single `TestRun` struct.