### PR TITLE
Modified the results summary UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Assuming you have a Kubernetes deployment in `deployment.yaml` you can run Conft
 $ conftest test deployment.yaml
 FAIL - deployment.yaml - Containers must not run as root
 FAIL - deployment.yaml - Deployments are not allowed
+
+2 tests, 0 passed, 0 warnings, 2 failures
 ```
 
 Conftest isn't specific to Kubernetes. It will happily let you write tests for any configuration files in a variety of different formats.

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -210,13 +210,13 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 8 ]
+  [ "$count" -eq 5 ]
 }
 
 @test "Can verify rego tests" {
   run ./conftest verify --policy ./examples/kubernetes/policy
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "PASS: 4/4" ]]
+  [[ "$output" =~ "4 tests, 4 passed" ]]
 }
 
 @test "Can parse inputs with 'conftest parse'" {
@@ -264,7 +264,7 @@
 @test "Can load data in unit tests" {
   run ./conftest verify -p examples/data/policy -d examples/data/exclusions examples/data/service.yaml
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "PASS" ]]
+  [[ "$output" =~ "1 test, 1 passed, 0 warnings, 0 failures" ]]
 }
 
 @test "Can update policies in test command" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ Assuming you have a Kubernetes deployment in `deployment.yaml` you can run `conf
 $ conftest test deployment.yaml
 FAIL - deployment.yaml - Containers must not run as root
 FAIL - deployment.yaml - Deployments are not allowed
+
+2 tests, 0 passed, 0 warnings, 2 failures
 ```
 
 `conftest` can also be used with stdin:
@@ -44,6 +46,8 @@ FAIL - deployment.yaml - Deployments are not allowed
 $ cat deployment.yaml | conftest test -
 FAIL - Containers must not run as root
 FAIL - Deployments are not allowed
+
+2 tests, 0 passed, 0 warnings, 2 failures
 ```
 
 Note that Conftest isn't specific to Kubernetes. It will happily let you write tests for any

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXn
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.3 h1:wS8NNaIgtzapuArKIAjsyXtEN/IUjQkbw90xszUdS40=
 github.com/OneOfOne/xxhash v1.2.3/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/OneOfOne/xxhash v1.2.7 h1:fzrmmkskv067ZQbd9wERNGuxckWw67dyzoMG62p7LMo=
+github.com/OneOfOne/xxhash v1.2.7/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -127,10 +127,33 @@ func (s *StandardOutputManager) Flush() error {
 
 	totalPolicies := totalFailures + totalWarnings + totalSuccesses
 
-	s.logger.Print("--------------------------------------------------------------------------------")
-	s.logger.Print("PASS: ", totalSuccesses, "/", totalPolicies)
-	s.logger.Print("WARN: ", totalWarnings, "/", totalPolicies)
-	s.logger.Print("FAIL: ", totalFailures, "/", totalPolicies)
+    var outputColor aurora.Color
+    if totalFailures > 0 {
+        outputColor = aurora.RedFg
+    } else if totalWarnings > 0 {
+        outputColor = aurora.YellowFg
+    } else {
+        outputColor = aurora.GreenFg
+    }
+
+    var pluralSuffixTests string
+    if totalPolicies != 1 {
+        pluralSuffixTests = "s"
+    }
+
+    var pluralSuffixWarnings string
+    if totalWarnings != 1 {
+        pluralSuffixWarnings = "s"
+    }
+
+    var pluralSuffixFailures string
+    if totalFailures != 1 {
+        pluralSuffixFailures = "s"
+    }
+
+    s.logger.Println()
+    outputText := fmt.Sprintf("%v test%s, %v passed, %v warning%s, %v failure%s", totalPolicies, pluralSuffixTests, totalSuccesses, totalWarnings, pluralSuffixWarnings, totalFailures, pluralSuffixFailures)
+    s.logger.Println(s.color.Colorize(outputText, outputColor))
 
 	return nil
 }

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -31,10 +31,8 @@ func Test_stdOutputManager_put(t *testing.T) {
 			exp: []string{
 				"WARN - foo.yaml - first warning",
 				"FAIL - foo.yaml - first failure",
-				"--------------------------------------------------------------------------------",
-				"PASS: 0/2",
-				"WARN: 1/2",
-				"FAIL: 1/2",
+                "",
+                "2 tests, 0 passed, 1 warning, 1 failure",
 			},
 		},
 		{
@@ -49,10 +47,8 @@ func Test_stdOutputManager_put(t *testing.T) {
 			exp: []string{
 				"WARN - first warning",
 				"FAIL - first failure",
-				"--------------------------------------------------------------------------------",
-				"PASS: 0/2",
-				"WARN: 1/2",
-				"FAIL: 1/2",
+                "",
+                "2 tests, 0 passed, 1 warning, 1 failure",
 			},
 		},
 	}


### PR DESCRIPTION
The previous output repeated information and took up quite a bit of
vertical space. It also had a fixed width line which didn't adjust to
the console size.

This streamlines it, adding a touch of colour to call attention to
failures. Inspired by rspec.

Fixes #281 