### PR TITLE
Adding additional tests for hcl parser

### DIFF
--- a/parser/hcl2/convert_test.go
+++ b/parser/hcl2/convert_test.go
@@ -10,7 +10,7 @@ import (
 
 // This file is mostly attributed to https://github.com/tmccombs/hcl2json
 
-const input = `
+const inputa = `
 resource "aws_elastic_beanstalk_environment" "example" {
 	name        = "test_environment"
 	application = "testing"
@@ -44,7 +44,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 	}
   }`
 
-const expectedJSON = `{
+const outputa = `{
 	"resource": {
 		"aws_elastic_beanstalk_environment": {
 			"example": {
@@ -77,24 +77,32 @@ const expectedJSON = `{
 
 // Test that conversion works as expected
 func TestConversion(t *testing.T) {
-	bytes := []byte(input)
-	conf, diags := hclsyntax.ParseConfig(bytes, "test", hcl.Pos{Byte: 0, Line: 1, Column: 1})
-	if diags.HasErrors() {
-		t.Errorf("Failed to parse config: %v", diags)
+	testTable := map[string]struct {
+		input  string
+		output string
+	}{
+		"simple": {input: inputa, output: outputa},
 	}
-	converted, err := convertFile(conf)
+	for name, tc := range testTable {
+		bytes := []byte(tc.input)
+		conf, diags := hclsyntax.ParseConfig(bytes, "test", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Errorf("Failed to parse config: %v", diags)
+		}
+		converted, err := convertFile(conf)
 
-	if err != nil {
-		t.Errorf("Unable to convert from hcl: %v", err)
-	}
+		if err != nil {
+			t.Errorf("Unable to convert from hcl: %v", err)
+		}
 
-	jb, err := json.MarshalIndent(converted, "", "\t")
-	if err != nil {
-		t.Errorf("Failed to serialize to json: %v", err)
-	}
-	computedJSON := string(jb)
+		jb, err := json.MarshalIndent(converted, "", "\t")
+		if err != nil {
+			t.Errorf("Failed to serialize to json: %v", err)
+		}
+		computedJSON := string(jb)
 
-	if computedJSON != expectedJSON {
-		t.Errorf("Expected:\n%s\n\nGot:\n%s", expectedJSON, computedJSON)
+		if computedJSON != tc.output {
+			t.Errorf("For test %s\nExpected:\n%s\n\nGot:\n%s", name, tc.output, computedJSON)
+		}
 	}
 }

--- a/parser/hcl2/convert_test.go
+++ b/parser/hcl2/convert_test.go
@@ -14,13 +14,13 @@ const inputa = `
 resource "aws_elastic_beanstalk_environment" "example" {
 	name        = "test_environment"
 	application = "testing"
-  
+
 	setting {
 	  namespace = "aws:autoscaling:asg"
 	  name      = "MinSize"
 	  value     = "1"
 	}
-  
+
 	dynamic "setting" {
 	  for_each = data.consul_key_prefix.environment.var
 	  content {
@@ -75,13 +75,57 @@ const outputa = `{
 	}
 }`
 
+const inputb = `
+provider "aws" {
+    version             = "=2.46.0"
+    alias                  = "one"
+}
+`
+
+const outputb = `{
+	"provider": {
+		"aws": {
+			"alias": "one",
+			"version": "=2.46.0"
+		}
+	}
+}`
+
+const inputc = `
+provider "aws" {
+    version             = "=2.46.0"
+    alias                  = "one"
+}
+provider "aws" {
+    version             = "=2.47.0"
+    alias                  = "two"
+}
+`
+
+const outputc = `{
+	"provider": {
+		"aws": [
+			{
+				"alias": "one",
+				"version": "=2.46.0"
+			},
+			{
+				"alias": "two",
+				"version": "=2.47.0"
+			}
+		]
+	}
+}`
+
 // Test that conversion works as expected
 func TestConversion(t *testing.T) {
 	testTable := map[string]struct {
 		input  string
 		output string
 	}{
-		"simple": {input: inputa, output: outputa},
+		"simple-resources": {input: inputa, output: outputa},
+		"single-provider":  {input: inputb, output: outputb},
+		"two-providers":    {input: inputc, output: outputc},
 	}
 	for name, tc := range testTable {
 		bytes := []byte(tc.input)


### PR DESCRIPTION
## Description

Relates to: #266 

I added a few more tests in the hcl parser for the `provider` block. The existing behavior when you've got a single provider is to have it as a collection vs two providers of the same type (`aws` as an example) with `aliases` you get a set of collections.

Regardless of the solution to #266 I think its worthwhile to have tests for the specific differences since this is specific only to the provider block in hcl. This isnt possible with other resources due to conflicting namespace.