### PR TITLE
Fix: incorrect total number of results

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -280,3 +280,9 @@
   run ./conftest kubectl
   [ "$status" -eq 0 ]
 }
+
+@test "The number of tests run is accurate" {
+  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
+  [ "$status" -eq 0 ]
+  [ "${lines[1]}" = "5 tests, 4 passed, 1 warning, 0 failures" ]
+}

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -298,12 +298,18 @@ func (t TestRun) runRules(ctx context.Context, namespace string, input interface
 	var errors []Result
 
 	var rules []string
+	var numberRules int = 0
 	for _, module := range t.Compiler.Modules {
-		for _, rule := range module.Rules {
-			ruleName := rule.Head.Name.String()
+		if strings.Split(module.Package.Path.String(), ".")[1] == namespace {
+			for _, rule := range module.Rules {
+				ruleName := rule.Head.Name.String()
 
-			if regex.MatchString(ruleName) && !stringInSlice(ruleName, rules) {
-				rules = append(rules, ruleName)
+				if regex.MatchString(ruleName) {
+					numberRules += 1
+					if !stringInSlice(ruleName, rules) {
+						rules = append(rules, ruleName)
+					}
+				}
 			}
 		}
 	}
@@ -329,6 +335,10 @@ func (t TestRun) runRules(ctx context.Context, namespace string, input interface
 
 		totalErrors = append(totalErrors, errors...)
 		totalSuccesses = append(totalSuccesses, successes...)
+	}
+
+	for i := len(totalErrors) + len(totalSuccesses); i < numberRules; i++ {
+		totalSuccesses = append(totalSuccesses, Result{})
 	}
 
 	return totalErrors, totalSuccesses, nil


### PR DESCRIPTION
This PR fixes the issue #275 raised by @corrupt952.

The root cause of the issue was the nature of contest rules: they tend to all be called the same (warn, deny, violation - despite the regex allowing for a broader range). This, resulted in all of the rules with the same name from the same package to be accounted for once if they passed (wrong behaviour), or individually if they failed.

Before the change:

```
$ ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
WARN - examples/kubernetes/service.yaml - Found service hello-kubernetes but services are not allowed

3 tests, 2 passed, 1 warning, 0 failures
```

After the change:

```
$ go run . test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
WARN - examples/kubernetes/service.yaml - Found service hello-kubernetes but services are not allowed

5 tests, 4 passed, 1 warning, 0 failures
```

I have also created a test case to ensure that this issue doesn't come back.