### PR TITLE
Opa/0.19.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/logrusorgru/aurora v0.0.0-20191116043053-66b7ad493a23
 	github.com/moby/buildkit v0.3.3
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/open-policy-agent/opa v0.18.0
+	github.com/open-policy-agent/opa v0.19.1
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/open-policy-agent/opa v0.18.0 h1:EC81mO3/517Kq5brJHydqKE5MLzJ+4cdJvUQKxLzHy8=
 github.com/open-policy-agent/opa v0.18.0/go.mod h1:6pC1cMYDI92i9EY/GoA2m+HcZlcCrh3jbfny5F7JVTA=
+github.com/open-policy-agent/opa v0.19.1 h1:jVopQC3LRwQTstVME8LDCNf6PZkShmmozDsvyp+DYZY=
+github.com/open-policy-agent/opa v0.19.1/go.mod h1:rrwxoT/b011T0cyj+gg2VvxqTtn6N3gp/jzmr3fjW44=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
Update the dependency on opa to the latest version. 0.19 had some internal changes which means that its significantly faster, for example:

before:

```
$ time conftest verify

412 tests, 412 passed, 0 warnings, 0 failures

real    0m5.911s
user    0m11.944s
sys     0m0.293s

```

after:

```
$ time conftest verify

412 tests, 412 passed, 0 warnings, 0 failures

real    0m0.825s
user    0m1.732s
sys     0m0.058s
```